### PR TITLE
Add sla_applied and statistics objects

### DIFF
--- a/tap_intercom/schemas/conversations.json
+++ b/tap_intercom/schemas/conversations.json
@@ -539,7 +539,6 @@
         "null",
         "object"
       ],
-      "additionalProperties": false,
           "properties": {
             "sla_name": {
               "type": [
@@ -566,7 +565,6 @@
         "null",
         "object"
       ],
-      "additionalProperties": false,
       "properties": {
         "type": {
           "type": [

--- a/tap_intercom/schemas/conversations.json
+++ b/tap_intercom/schemas/conversations.json
@@ -539,21 +539,21 @@
         "null",
         "object"
       ],
-          "properties": {
-            "sla_name": {
-              "type": [
-                "null",
-                "string"
-           ]
-          },
-            "sla_status": {
-              "type": [
-                "null",
-                "string"
+      "properties": {
+        "sla_name": {
+          "type": [
+            "null",
+            "string"
           ]
-          }
+        },
+        "sla_status": {
+          "type": [
+            "null",
+            "string"
+          ]
         }
-      },
+      }
+    },
     "state": {
       "type": [
         "null",

--- a/tap_intercom/schemas/conversations.json
+++ b/tap_intercom/schemas/conversations.json
@@ -534,11 +534,164 @@
       ],
       "format": "date-time"
     },
+    "sla_applied": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+          "properties": {
+            "sla_name": {
+              "type": [
+                "null",
+                "string"
+           ]
+          },
+            "sla_status": {
+              "type": [
+                "null",
+                "string"
+          ]
+          }
+        }
+      },
     "state": {
       "type": [
         "null",
         "string"
       ]
+    },
+    "statistics": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "time_to_assignment": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "time_to_admin_reply": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "time_to_first_close": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "time_to_last_close": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "median_time_to_reply": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "first_contact_reply_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "first_assignment_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "first_admin_reply_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "first_close_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_assignment_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_assignment_admin_reply_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_contact_reply_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_admin_reply_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_close_at": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "last_closed_by_id": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "count_reopens": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "count_assignments": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "count_conversation_parts": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      }
     },
     "tags": {
       "type": [


### PR DESCRIPTION
# Description of change
- Adds two objects to the list of fields for the conversations stream, including `sla_applied` and `statistics`

# Manual QA steps
 - Ran the branch locally and compared output to that of a cURL request against the Intercom API using version 2.0.
 
# Risks
 - Invalid datatypes could cause schema violations. Notably, our Intercom account does not have access to the SLA functionality, so there was no output specific to this object. Instead, Intercom's documentation was used as reference and both properties in that stream are strings, so the risk is low.
- There are currently no automated tests surrounding this stream to my knowledge, so I was not able to validate the functionality with QA tests.
 
# Rollback steps
 - revert this branch
