### PR TITLE
bumped version to 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.0
+  * Add `sla_applied` and `statistics` objects.
+
 ## 0.0.4
   * Adjust `client.py` to use API `v.2.0`.
   * Remove `users` and `leads` streams.

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='0.0.4',
+      version='0.1.0',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
bumping version for tap-intercom to 0.1.0

# Manual QA steps
 - none
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
