### PR TITLE
Fix inconsistent epoch timestamps from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.1
+  * Fix for inconsistem epoch formats from API. Normalize all to milli.
+
 ## 1.0.0
   * Bumping to first major version 1.0.0 for GA Release
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='1.0.0',
+      version='1.0.1',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_intercom/sync.py
+++ b/tap_intercom/sync.py
@@ -80,7 +80,7 @@ def process_records(catalog, #pylint: disable=too-many-branches
             if parent_id and parent:
                 record[parent + '_id'] = parent_id
 
-            
+
             # API returns inconsistent epoch representations sec AND millis
             # Normalizes to millisecond for transformer
             transform_epochs(record, schema_datetimes)

--- a/tap_intercom/transform.py
+++ b/tap_intercom/transform.py
@@ -1,4 +1,6 @@
 # De-nest each list node up to record level
+import math as m
+
 def denest_list_nodes(this_json, data_key, list_nodes):
     new_json = this_json
     i = 0
@@ -61,8 +63,17 @@ def find_datetimes_in_schema(schema):
             datetimes.append(element)
     return datetimes
 
+def get_integer_places(value):
+    if value <= 999999999999997:
+        return int(m.log10(value)) + 1
+    counter = 15
+    while value >= 10**counter:
+        counter += 1
+    return counter
+
 
 def transform_epochs(record, schema_datetimes):
     for datetime in schema_datetimes:
-        if datetime in record and record[datetime]:
+        if datetime in record and record[datetime] and get_integer_places(
+                record[datetime]) == 10:
             record[datetime] = record[datetime] * 1000

--- a/tap_intercom/transform.py
+++ b/tap_intercom/transform.py
@@ -1,6 +1,7 @@
-# De-nest each list node up to record level
 import math as m
 
+
+# De-nest each list node up to record level
 def denest_list_nodes(this_json, data_key, list_nodes):
     new_json = this_json
     i = 0
@@ -71,7 +72,7 @@ def get_integer_places(value):
         counter += 1
     return counter
 
-
+# Only want to transform seconds to millis here
 def transform_epochs(record, schema_datetimes):
     for datetime in schema_datetimes:
         if datetime in record and record[datetime] and get_integer_places(

--- a/tap_intercom/transform.py
+++ b/tap_intercom/transform.py
@@ -52,3 +52,17 @@ def transform_json(this_json, stream_name, data_key):
     if data_key in new_json:
         return new_json[data_key]
     return new_json
+
+
+def find_datetimes_in_schema(schema):
+    datetimes = []
+    for element, value in schema['properties'].items():
+        if 'format' in value and value['format'] == 'date-time':
+            datetimes.append(element)
+    return datetimes
+
+
+def transform_epochs(record, schema_datetimes):
+    for datetime in schema_datetimes:
+        if datetime in record and record[datetime]:
+            record[datetime] = record[datetime] * 1000


### PR DESCRIPTION
# Description of change
Issue: Intercom API returns a record with mixed epoch millisecond and epoch seconds integers. Ex:
{'signed_up_at': 1467133937045, 'created_at': 1467133614}

Normalizes all timestamps, via transform function, to millisecond.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
