### PR TITLE
Transform nested datetimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.0.3
+  * Ensure nested times are transformed
+
 ## 1.0.2
   * Support date time strings from API in tranform
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='1.0.2',
+      version='1.0.3',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_intercom/transform.py
+++ b/tap_intercom/transform.py
@@ -59,12 +59,22 @@ def transform_json(this_json, stream_name, data_key):
     return new_json
 
 
+# Traverse schema and find all date-times where
+# a path is the array of keys needed to descend
+# the schema(tree) to locate the desired value.
+# Returns an array of path arrays.
 def find_datetimes_in_schema(schema):
-    datetimes = []
-    for element, value in schema['properties'].items():
-        if 'format' in value and value['format'] == 'date-time':
-            datetimes.append(element)
-    return datetimes
+    paths = []
+    if 'properties' in schema and isinstance(schema, dict):
+        for k, v in schema['properties'].items():
+            if 'format' in v and v['format'] == 'date-time':
+                paths.append([k])
+            else:
+                paths += [
+                    [k] + x for x in find_datetimes_in_schema(v)
+                ]
+    return paths
+
 
 def get_integer_places(value):
     if value <= 999999999999997:
@@ -74,15 +84,30 @@ def get_integer_places(value):
         counter += 1
     return counter
 
+# Traverse dict by array of keys and return path's value
+def nested_get(dic, keys):
+    for key in keys:
+        if dic and key in dic:
+            dic = dic[key]
+        else:
+            return None
+    return dic
+
+# Set nested value by arrray of keys as path
+def nested_set(dic, keys, value):
+    for key in keys[:-1]:
+        dic = dic.setdefault(key, {})
+    dic[keys[-1]] = value
 
 # API returns date times, epoch seconds and epoch millis
 # Transform datetimes to epoch millis
 # Transform epoch seconds to millis
 def transform_times(record, schema_datetimes):
-    for datetime in schema_datetimes:
-        if datetime in record and record[datetime]:
-            if isinstance(record[datetime], str):
-                record[datetime] = strptime_to_utc(
-                    record[datetime]).timestamp() * 1000
-            elif get_integer_places(record[datetime]) == 10:
-                record[datetime] = record[datetime] * 1000
+    for datetime_path in schema_datetimes:
+        datetime = nested_get(record, datetime_path)
+
+        if datetime and isinstance(datetime, str):
+            converted_ts = strptime_to_utc(datetime).timestamp() * 1000
+            nested_set(record, datetime_path, converted_ts)
+        elif datetime and get_integer_places(datetime) == 10:
+            nested_set(record, datetime_path, datetime * 1000)


### PR DESCRIPTION
# Description of change
API inconsistently return date times, epoch seconds and epoch millis. The Tap's usage of Singer Transformed expects epoch milli only.

```
with Transformer(integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) \
```

Previously in https://github.com/singer-io/tap-intercom/pull/12 a method to normalize all API times to epoch millis was added. However, this did not transform nested times. This change ensures nested date times are transformed. 

# Manual QA steps
Ran with singer-discover, singer target-stitch initial and incremental. Evaluatated time data synced into the datawarehouse now transformed correctly:

conversations.first_contact_reply
```
{ "created_at": "2020-11-17T19:57:01Z", "type": "conversation", "url": "https://app.stitchdata.com/client/178677/pipeline/v2/sources/add" }
```
 
# Risks
Medium risk. Does not affect schema or primary keys, however, clients may want to re-sync history. 
 
# Rollback steps
 - revert to previous version
