### PR TITLE
Default pagination to 150

### DIFF
--- a/tap_intercom/sync.py
+++ b/tap_intercom/sync.py
@@ -165,8 +165,8 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
     # pagination: loop thru all pages of data using next_url (if not None)
     page = 1
     offset = 0
-    # Default per_page limit is 50, max is 60
-    limit = endpoint_config.get('batch_size', 60)
+    # Default per_page limit is 50, max is 150
+    limit = endpoint_config.get('batch_size', 150)
     total_records = 0
 
     # Check scroll_type to determine if to use Scroll API


### PR DESCRIPTION
The Intercom 2.0 API now supports 150 entries returned per call for Pagination objects.

https://developers.intercom.com/intercom-api-reference/v2.0/reference#pagination

# Description of change
In the move from the 1.4 API to to 2.0 API Intercom raised the records per page limit in a Pagination Object to 150. Updating to use this limit should give better throughput and reduce overall API calls to Intercom.

# Manual QA steps
 - 
 
# Risks
 - Could I have missed somewhere that it is still restricted to 60?
 
# Rollback steps
 - revert this branch
