### PR TITLE
Fix negative timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable
+	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return
 	nosetests

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ reference#list-customer-data-attributes)
     | companies           | 7182    | 1       |
     +---------------------+---------+---------+
     ```
+
+    To run unit tests run the following command:
+    ```
+    python -m nose
+    ```
 ---
 
 Copyright &copy; 2019 Stitch

--- a/tap_intercom/tests/test_transform.py
+++ b/tap_intercom/tests/test_transform.py
@@ -1,0 +1,36 @@
+import nose
+from singer.transform import unix_milliseconds_to_datetime
+from tap_intercom.transform import get_integer_places
+
+
+def test_get_integer_places():
+
+    input_output_mapping = {
+        -62135596800: 10,
+        62135596800: 11,
+        1612998233: 10,
+        -1: 10,
+        -9999999999999: 10,
+        -999999999999997: 10,
+        1612998430000: 13,
+        9999999999999999: 16,
+    }
+
+    for input_values, expected_values in input_output_mapping.items():
+        assert expected_values == get_integer_places(input_values)
+
+
+def test_unix_milliseconds_to_datetime():
+
+    input_output_mapping = {
+        -62135596800: "1968-01-12T20:06:43.200000Z",
+        62135596800: "1971-12-21T03:53:16.800000Z",
+        99999999999999: "5138-11-16T09:46:39.998993Z",
+        -1: "1969-12-31T23:59:59.999000Z",
+    }
+    for input_values, expected_values in input_output_mapping.items():
+        assert expected_values == unix_milliseconds_to_datetime(input_values)
+
+
+if __name__ == '__main__':
+    nose.run()

--- a/tap_intercom/transform.py
+++ b/tap_intercom/transform.py
@@ -67,12 +67,15 @@ def find_datetimes_in_schema(schema):
     return datetimes
 
 def get_integer_places(value):
-    if value <= 999999999999997:
+    if 0 <= value <= 999999999999997:
         return int(m.log10(value)) + 1
-    counter = 15
-    while value >= 10**counter:
-        counter += 1
-    return counter
+    elif value < 0:
+        return 10
+    else:
+        counter = 15
+        while value >= 10**counter:
+            counter += 1
+        return counter
 
 
 # API returns date times, epoch seconds and epoch millis


### PR DESCRIPTION
Copied from #22. Moved into branch on this repo so circleci would run.

# Description of change
API returns negative timestamps on occasion. Technically, a negative timestamp value is not invalid as it is simply a date prior to 01-01-1970 but it is likely that this is just bad data being sent by the Intercom API as one of the examples was sending back a negative timestamp for the `signed_up_at` field. Furthermore, the API is also inconsistent about sending timestamps in unix seconds or unix milliseconds so the `get_integer_places` function was designed to try and determine the units of the timestamp. This is where passing in a negative timestamp would cause the program to fail because the function tries to take the log of a value but you cannot take the log of a negative number. This fix only prevents the program from failing when given a negative timestamp but does not try to determine if the timestamp is in seconds or milliseconds as 1) it would not be guaranteed anyway and 2) it is likely bad data anyway. Furthermore, unit tests are included to ensure that the `get_integer_places` function will properly handle negative timestamps and that these negative timestamps will be properly converted to string dates downstream.

# Manual QA steps
 - Run `python -m nose` to run unit tests.
 
# Risks
 - Negative timestamp could affect a different branch of logic.
 
# Rollback steps
 - revert this branch
