### PR TITLE
Admins activity logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This tap:
 - Pulls raw data from the [Intercom v1.4 API](https://developers.intercom.com/intercom-api-reference/reference#introduction)
 - Extracts the following resources:
   - [Admins](https://developers.intercom.com/intercom-api-reference/reference#list-admins)
+  - [Admins Activity Logs](https://developers.intercom.com/intercom-api-reference/reference#view-admin-activity-logs)
   - [Companies](https://developers.intercom.com/intercom-api-reference/reference#list-companies)
   - [Conversations](https://developers.intercom.com/intercom-api-reference/reference#list-conversations)
     - [Conversation Parts](https://developers.intercom.com/intercom-api-reference/reference#get-a-single-conversation)
@@ -32,6 +33,15 @@ This tap:
 - Primary key fields: id
 - Foreign key fields: team_ids
 - Replication strategy: FULL_TABLE
+- Transformations: none
+
+[admins_activity_logs](https://developers.intercom.com/intercom-api-reference/reference#view-admin-activity-logs)
+- Endpoint: https://api.intercom.io/admins/activity_logs
+- Primary key fields: id
+- Foreign key fields: performed_by > id
+- Replication strategy: INCREMENTAL
+  - Bookmark: created_at (date-time)
+  - Bookmark query field: created_at_after
 - Transformations: none
 
 [companies](https://developers.intercom.com/intercom-api-reference/reference#list-companies)

--- a/tap_intercom/schemas/admins_activity_logs.json
+++ b/tap_intercom/schemas/admins_activity_logs.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": ["null", "string"]
+    },
+    "activity_type": {
+      "type": ["null", "string"]
+    },
+    "activity_description": {
+      "type": ["null", "string"]
+    },
+    "created_at": {
+      "type": ["null", "string"],
+      "format": "date-time"
+    },
+    "metadata": {
+      "type": ["null", "object"],
+      "additionalProperties": true
+    },
+    "performed_by": {
+      "type": ["null", "object"],
+      "additionalProperties": false,
+      "properties": {
+        "type" : {
+          "type":  ["null", "string"]
+        },
+        "id" : {
+          "type":  ["null", "string"]
+        },
+        "ip" : {
+          "type":  ["null", "string"]
+        },
+        "email" : {
+          "type":  ["null", "string"]
+        }
+      }
+    }
+  }
+}

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -155,6 +155,15 @@ STREAMS = {
         'key_properties': ['id'],
         'replication_method': 'FULL_TABLE'
     },
+    'admins_activity_logs': {
+        'key_properties': ['id'],
+        'replication_method': 'INCREMENTAL',
+        'replication_keys': ['created_at'],
+        'bookmark_type': 'datetime',
+        'data_key': 'activity_logs',
+        'path': 'admins/activity_logs',
+        'bookmark_query_field': 'created_at_after'
+    },
 }
 
 


### PR DESCRIPTION
# Description of change
Adding admins activity logs stream as documented in https://developers.intercom.com/intercom-api-reference/reference#view-admin-activity-logs

# QA steps
 - [X] automated tests passing
 - [X] manual qa steps passing (list below)
   `tap-intercom --config config.json --discover > catalog.json` > admin activity logs present in JSON File
   `tap-intercom --config config.json --catalog catalog.json | singer-check-tap > state_check.json` 

  ```Checking stdin for valid Singer-formatted data
  The output is valid.
  It contained 169 messages for 1 streams.
  
        1 schema messages
      155 record messages
       13 state messages
  
  Details by stream:
  +----------------------+---------+---------+
  | stream               | records | schemas |
  +----------------------+---------+---------+
  | admins_activity_logs | 155     | 1       |
  +----------------------+---------+---------+
  ```
  
# Risks

# Rollback steps
 - revert this branch