### PR TITLE
TDL-16402 Implement request timeouts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,14 +34,7 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/tap_tester_sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-intercom \
-                       --target=target-stitch \
-                       --orchestrator=stitch-orchestrator \
-                       --email=harrison+sandboxtest@stitchdata.com \
-                       --password=$SANDBOX_PASSWORD \
-                       --client-id=50 \
-                       --token=$STITCH_API_TOKEN \
-                       tests
+            run-test --tap=tap-intercom tests
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,16 +11,17 @@ jobs:
             python3 -mvenv /usr/local/share/virtualenvs/tap-intercom
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
             pip install .[dev]
+            pip install coverage
       - run:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
-            make test
+            pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding
       - run:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
-            nosetests tests/unittests/
+            nosetests --with-coverage --cover-erase --cover-package=tap_intercom --cover-html-dir=htmlcov tests/unittests/
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
             nosetests --with-coverage --cover-erase --cover-package=tap_intercom --cover-html-dir=htmlcov tests/unittests/
+            coverage html
       - store_test_results:
           path: test_output/report.xml
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,10 @@ jobs:
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
             nosetests --with-coverage --cover-erase --cover-package=tap_intercom --cover-html-dir=htmlcov tests/unittests/
+      - store_test_results:
+          path: test_output/report.xml
+      - store_artifacts:
+          path: htmlcov
       - add_ssh_keys
       - run:
           name: 'Integration Tests'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'pylint'
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
-            pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding
+            make test
       - run:
           name: 'Unit Tests'
           command: |

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return
-	nosetests tests/unittests
+	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding

--- a/README.md
+++ b/README.md
@@ -152,12 +152,13 @@ reference#list-customer-data-attributes)
     - [singer-tools](https://github.com/singer-io/singer-tools)
     - [target-stitch](https://github.com/singer-io/target-stitch)
 
-3. Create your tap's `config.json` file. Intercom [Authentication Types](https://developers.intercom.com/building-apps/docs/authentication-types) explains how to get an `access_token`. Make sure your [OAuth Scope](https://developers.intercom.com/building-apps/docs/oauth-scopes) allows Read access to the endpoints above. Additionally, your App should use [API Version ](https://developers.intercom.com/building-apps/docs/update-your-api-version) **[v1.4](https://developers.intercom.com/intercom-api-reference/v1.4/reference)**.
+3. Create your tap's `config.json` file. Intercom [Authentication Types](https://developers.intercom.com/building-apps/docs/authentication-types) explains how to get an `access_token`. Make sure your [OAuth Scope](https://developers.intercom.com/building-apps/docs/oauth-scopes) allows Read access to the endpoints above. Additionally, your App should use [API Version ](https://developers.intercom.com/building-apps/docs/update-your-api-version) **[v1.4](https://developers.intercom.com/intercom-api-reference/v1.4/reference)**. `request_timeout` is the time for which request should wait to get response. It is an optional parameter and default request_timeout is 300 seconds.
 
     ```json
     {
         "access_token": "YOUR_API_ACCESS_TOKEN",
         "start_date": "2019-01-01T00:00:00Z",
+        "request_timeout": 300,
         "user_agent": "tap-intercom <api_user_email@your_company.com>"
     }
     ```

--- a/config.json.example
+++ b/config.json.example
@@ -1,5 +1,6 @@
 {
     "access_token": "YOUR_API_ACCESS_TOKEN",
     "start_date": "2019-01-01T00:00:00Z",
+    "request_timeout": 300,
     "user_agent": "tap-intercom <api_user_email@your_company.com>"
 }

--- a/tap_intercom/client.py
+++ b/tap_intercom/client.py
@@ -192,7 +192,7 @@ class IntercomClient(object):
 
     # Rate limiting:
     #  https://developers.intercom.com/intercom-api-reference/reference#rate-limiting
-    @backoff.on_exception(backoff.expo,Timeout, max_tries=5, factor=2) # Backoff for request timeout
+    @backoff.on_exception(backoff.expo, Timeout, max_tries=5, factor=2) # Backoff for request timeout
     @backoff.on_exception(backoff.expo,
                           (Server5xxError, ConnectionError, Server429Error, IntercomScrollExistsError),
                           max_tries=7,

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -83,7 +83,9 @@ class IncrementalStream(BaseStream):
     """
     replication_method = 'INCREMENTAL'
 
-    # pylint: disable=too-many-arguments
+    # Disabled `unused-argument` as it causing pylint error.
+    # Method which call this `sync` method is passing unused argument.So, removing argument would not work.
+    # pylint: disable=too-many-arguments,unused-argument
     def sync(self,
              state: dict,
              stream_schema: dict,
@@ -145,7 +147,9 @@ class FullTableStream(BaseStream):
     """
     replication_method = 'FULL_TABLE'
 
-    # pylint: disable=too-many-arguments
+    # Disabled `unused-argument` as it causing pylint error.
+    # Method which call this `sync` method is passing unused argument. So, removing argument would not work.
+    # pylint: disable=too-many-arguments,unused-argument
     def sync(self,
              state: dict,
              stream_schema: dict,

--- a/tap_intercom/sync.py
+++ b/tap_intercom/sync.py
@@ -12,7 +12,7 @@ def sync(config, state, catalog):
     """ Sync data from tap source """
 
     access_token = config.get('access_token')
-    client = IntercomClient(access_token, config.get('user_agent'))
+    client = IntercomClient(access_token, config.get('request_timeout'), config.get('user_agent')) # pass request_timeout parameter from config
 
     with Transformer() as transformer:
         for stream in catalog.get_selected_streams(state):

--- a/tests/unittests/test_request_timeouts.py
+++ b/tests/unittests/test_request_timeouts.py
@@ -48,11 +48,10 @@ class TestRequestTimeoutsBackoff(unittest.TestCase):
         # Verify that requests.Session.request is called 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
-@patch("time.sleep")
 @patch("requests.Session.request", side_effect = get_mock_http_response)
 @patch("tap_intercom.client.IntercomClient.check_access_token")
 class TestRequestTimeoutsValue(unittest.TestCase):
-    def test_no_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_no_request_timeout_in_config(self, mocked_token, mocked_request):
         """
         Verify that if request_timeout is not provided in config then default value is used
         """
@@ -66,7 +65,7 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
-    def test_integer_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_integer_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config(integer value) then it should be use
         """
@@ -80,7 +79,7 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
 
-    def test_float_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_float_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config(float value) then it should be use
         """
@@ -94,7 +93,7 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
 
-    def test_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_string_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config(string value) then it should be use
         """
@@ -108,7 +107,7 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
 
-    def test_empty_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_empty_string_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config with empty string then default value is used
         """
@@ -122,13 +121,13 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
-    def test_zero_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_zero_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config with zero value then default value is used
         """
         # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', 0)# int zero value timeout in config
-   
+        
         # Call request method which call requests.Session.request with timeout
         client.request("base_url")
 
@@ -136,13 +135,13 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
-    def test_zero_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+    def test_zero_string_request_timeout_in_config(self, mocked_token, mocked_request):
         """
             Verify that if request_timeout is provided in config with zero in string format then default value is used
         """
         # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', "0")# string 0 timeout in config
-     
+        
         # Call request method which call requests.Session.request with timeout
         client.request("base_url")
 

--- a/tests/unittests/test_request_timeouts.py
+++ b/tests/unittests/test_request_timeouts.py
@@ -1,0 +1,259 @@
+
+import unittest
+from unittest.mock import patch
+from requests.exceptions import Timeout
+from tap_intercom.client import IntercomClient
+
+REQUEST_TIMEOUT_INT = 300
+REQUEST_TIMEOUT_STR = "300"
+REQUEST_TIMEOUT_FLOAT = 300.0
+
+@patch("time.sleep")
+@patch("requests.Session.get", side_effect=Timeout)
+class TestRequestTimeoutsInCheckAccessToken(unittest.TestCase):
+    """
+    Verify that tap retry 5 times on Timeout error raise from check_access_token method
+    """
+    def test_no_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+        Verify that if request_timeout is not provided in config then default value is used
+        """
+        client = IntercomClient('dummy_token', None)
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_integer_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(integer value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# int timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_float_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(float value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_FLOAT)# float timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_string_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(string value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_empty_string_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with empty string then default value is used
+        """
+        client = IntercomClient('dummy_token', "")# empty string timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_zero_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with zero value then default value is used
+        """
+        client = IntercomClient('dummy_token', 0)# int zero value timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+    def test_zero_string_request_timeout_in_config(self, mocked_get, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with zero in string format then default value is used
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string 0 timeout in config
+        try:
+            client.__enter__()
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_get.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.get is called 5 times
+        self.assertEqual(mocked_get.call_count, 5)
+
+@patch("time.sleep")
+@patch("requests.Session.request", side_effect=Timeout)
+@patch("tap_intercom.client.IntercomClient.check_access_token")
+class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
+    """
+    Verify that tap retry 5 times on Timeout error raise from request method
+    """
+    def test_no_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+        Verify that if request_timeout is not provided in config then default value is used
+        """
+        client = IntercomClient('dummy_token', None)
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+        # Verify requests.Session.get is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_integer_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(integer value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# int timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_float_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(float value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_FLOAT)# float timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config(string value) then it should be use
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_empty_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with empty string then default value is used
+        """
+        client = IntercomClient('dummy_token', "")# empty string timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_zero_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with zero value then default value is used
+        """
+        client = IntercomClient('dummy_token', 0)# int zero value timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
+
+    def test_zero_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
+        """
+            Verify that if request_timeout is provided in config with zero in string format then default value is used
+        """
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string 0 timeout in config
+        try:
+            client.request("base_url")
+        except Timeout:
+            pass
+
+        # Verify requests.Session.request is called with expected timeout
+        args, kwargs = mocked_request.call_args
+        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
+
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_request_timeouts.py
+++ b/tests/unittests/test_request_timeouts.py
@@ -10,13 +10,11 @@ REQUEST_TIMEOUT_FLOAT = 300.0
 
 @patch("time.sleep")
 @patch("requests.Session.get", side_effect=Timeout)
-class TestRequestTimeoutsInCheckAccessToken(unittest.TestCase):
-    """
-    Verify that tap retry 5 times on Timeout error raise from check_access_token method
-    """
-    def test_no_request_timeout_in_config(self, mocked_get, mock_sleep):
+class TestRequestTimeoutsBackoff(unittest.TestCase):
+
+    def test_request_timeout_backoff_in_check_access_token(self, mocked_request, mocked_sleep):
         """
-        Verify that if request_timeout is not provided in config then default value is used
+            Verify check_access_token function is backoff for 5 times on Timeout exceeption
         """
         client = IntercomClient('dummy_token', None)
         try:
@@ -24,121 +22,26 @@ class TestRequestTimeoutsInCheckAccessToken(unittest.TestCase):
         except Timeout:
             pass
 
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
         # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
+        self.assertEqual(mocked_request.call_count, 5)
 
-    def test_integer_request_timeout_in_config(self, mocked_get, mock_sleep):
+    def test_request_timeout_backoff_in_request(self, mocked_request, mocked_sleep):
         """
-            Verify that if request_timeout is provided in config(integer value) then it should be use
-        """
-        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# int timeout in config
-        try:
-            client.__enter__()
-        except Timeout:
-            pass
-
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
-
-    def test_float_request_timeout_in_config(self, mocked_get, mock_sleep):
-        """
-            Verify that if request_timeout is provided in config(float value) then it should be use
-        """
-        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_FLOAT)# float timeout in config
-        try:
-            client.__enter__()
-        except Timeout:
-            pass
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
-
-    def test_string_request_timeout_in_config(self, mocked_get, mock_sleep):
-        """
-            Verify that if request_timeout is provided in config(string value) then it should be use
-        """
-        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string timeout in config
-        try:
-            client.__enter__()
-        except Timeout:
-            pass
-
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
-
-    def test_empty_string_request_timeout_in_config(self, mocked_get, mock_sleep):
-        """
-            Verify that if request_timeout is provided in config with empty string then default value is used
-        """
-        client = IntercomClient('dummy_token', "")# empty string timeout in config
-        try:
-            client.__enter__()
-        except Timeout:
-            pass
-
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
-
-    def test_zero_request_timeout_in_config(self, mocked_get, mock_sleep):
-        """
-            Verify that if request_timeout is provided in config with zero value then default value is used
-        """
-        client = IntercomClient('dummy_token', 0)# int zero value timeout in config
-        try:
-            client.__enter__()
-        except Timeout:
-            pass
-
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
-
-    def test_zero_string_request_timeout_in_config(self, mocked_get, mock_sleep):
-        """
-            Verify that if request_timeout is provided in config with zero in string format then default value is used
+            Verify request function is backoff for 5 times on Timeout exceeption
         """
         client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string 0 timeout in config
         try:
-            client.__enter__()
+            client.request("base_url")
         except Timeout:
             pass
 
-        # Verify requests.Session.get is called with expected timeout
-        args, kwargs = mocked_get.call_args
-        self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
-        # Verify that requests.Session.get is called 5 times
-        self.assertEqual(mocked_get.call_count, 5)
+        # Verify that requests.Session.request is called 5 times
+        self.assertEqual(mocked_request.call_count, 5)
 
 @patch("time.sleep")
 @patch("requests.Session.request", side_effect=Timeout)
 @patch("tap_intercom.client.IntercomClient.check_access_token")
-class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
-    """
-    Verify that tap retry 5 times on Timeout error raise from request method
-    """
+class TestRequestTimeoutsValue(unittest.TestCase):
     def test_no_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
         Verify that if request_timeout is not provided in config then default value is used
@@ -153,9 +56,6 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
-
     def test_integer_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
             Verify that if request_timeout is provided in config(integer value) then it should be use
@@ -166,13 +66,9 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         except Timeout:
             pass
 
-
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
-
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
 
     def test_float_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
@@ -186,9 +82,6 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
-
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
 
     def test_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
@@ -204,9 +97,6 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
 
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
-
     def test_empty_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
             Verify that if request_timeout is provided in config with empty string then default value is used
@@ -220,9 +110,6 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
 
     def test_zero_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
@@ -238,9 +125,6 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)
-
     def test_zero_string_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
             Verify that if request_timeout is provided in config with zero in string format then default value is used
@@ -254,6 +138,3 @@ class TestRequestTimeoutsInRequestMethod(unittest.TestCase):
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
-
-        # Verify that requests.Session.request is called 5 times
-        self.assertEqual(mocked_request.call_count, 5)

--- a/tests/unittests/test_request_timeouts.py
+++ b/tests/unittests/test_request_timeouts.py
@@ -1,25 +1,34 @@
 
 import unittest
 from unittest.mock import patch
-from requests.exceptions import Timeout
+import requests
 from tap_intercom.client import IntercomClient
 
 REQUEST_TIMEOUT_INT = 300
 REQUEST_TIMEOUT_STR = "300"
 REQUEST_TIMEOUT_FLOAT = 300.0
 
+# Mock response object
+def get_mock_http_response(*args, **kwargs):
+    contents = '{"access_token": "test", "expires_in":100, "accounts":[{"id": 12}]}'
+    response = requests.Response()
+    response.status_code = 200
+    response._content = contents.encode()
+    return response
+
 @patch("time.sleep")
-@patch("requests.Session.get", side_effect=Timeout)
+@patch("requests.Session.get", side_effect=requests.exceptions.Timeout)
 class TestRequestTimeoutsBackoff(unittest.TestCase):
 
     def test_request_timeout_backoff_in_check_access_token(self, mocked_request, mocked_sleep):
         """
             Verify check_access_token function is backoff for 5 times on Timeout exceeption
         """
+        # Initialize IntercomClient object
         client = IntercomClient('dummy_token', None)
         try:
             client.__enter__()
-        except Timeout:
+        except requests.exceptions.Timeout:
             pass
 
         # Verify that requests.Session.request is called 5 times
@@ -29,30 +38,31 @@ class TestRequestTimeoutsBackoff(unittest.TestCase):
         """
             Verify request function is backoff for 5 times on Timeout exceeption
         """
+        # Initialize IntercomClient object
         client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string 0 timeout in config
         try:
             client.request("base_url")
-        except Timeout:
+        except requests.exceptions.Timeout:
             pass
 
         # Verify that requests.Session.request is called 5 times
         self.assertEqual(mocked_request.call_count, 5)
 
 @patch("time.sleep")
-@patch("requests.Session.request", side_effect=Timeout)
+@patch("requests.Session.request", side_effect = get_mock_http_response)
 @patch("tap_intercom.client.IntercomClient.check_access_token")
 class TestRequestTimeoutsValue(unittest.TestCase):
     def test_no_request_timeout_in_config(self, mocked_token, mocked_request, mock_sleep):
         """
         Verify that if request_timeout is not provided in config then default value is used
         """
+        # Initialize IntercomClient object
         client = IntercomClient('dummy_token', None)
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
 
-        # Verify requests.Session.get is called with expected timeout
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
+
+        # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_INT) # Verify timeout argument
 
@@ -60,12 +70,12 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config(integer value) then it should be use
         """
+        # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# int timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
-
+        
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
+        
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
@@ -74,11 +84,12 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config(float value) then it should be use
         """
+        # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', REQUEST_TIMEOUT_FLOAT)# float timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
+        
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
+        
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
@@ -87,12 +98,12 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config(string value) then it should be use
         """
-        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
-
+        # Initialize IntercomClient object with request_timeout
+        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_STR)# string timeout in config
+        
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
+        
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
         self.assertEqual(kwargs.get('timeout'), REQUEST_TIMEOUT_FLOAT) # Verify timeout argument
@@ -101,11 +112,11 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config with empty string then default value is used
         """
+        # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', "")# empty string timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
+        
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
 
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
@@ -115,11 +126,11 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config with zero value then default value is used
         """
+        # Initialize IntercomClient object with request_timeout
         client = IntercomClient('dummy_token', 0)# int zero value timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
+   
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
 
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args
@@ -129,11 +140,11 @@ class TestRequestTimeoutsValue(unittest.TestCase):
         """
             Verify that if request_timeout is provided in config with zero in string format then default value is used
         """
-        client = IntercomClient('dummy_token', REQUEST_TIMEOUT_INT)# string 0 timeout in config
-        try:
-            client.request("base_url")
-        except Timeout:
-            pass
+        # Initialize IntercomClient object with request_timeout
+        client = IntercomClient('dummy_token', "0")# string 0 timeout in config
+     
+        # Call request method which call requests.Session.request with timeout
+        client.request("base_url")
 
         # Verify requests.Session.request is called with expected timeout
         args, kwargs = mocked_request.call_args


### PR DESCRIPTION
# Description of change
- Implemented request timeout.
- Added unittest case for the same.
- If config parameter does not pass or pass the value "", "0", 0, "0.0" then set timeout to default value 5min

# Manual QA steps
 - Set small timeout and verify that sync calls are backing off for timeout error.
- Provide timeout in integer, float, and string format and verify that it's used in the request.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
