### PR TITLE
TDL-16981: Fix 'str' has no attribute get for getting bookmark

### DIFF
--- a/tap_intercom/sync.py
+++ b/tap_intercom/sync.py
@@ -10,7 +10,7 @@ LOGGER = singer.get_logger()
 
 def translate_state(state):
     """
-    Tap was used to write bookmark using custom get_bookmark and write_bookmark methods, 
+    Tap was used to write bookmark using custom get_bookmark and write_bookmark methods,
     in which case the state looked like the following format.
     {
         "bookmarks": {

--- a/tests/unittests/test_translate_state.py
+++ b/tests/unittests/test_translate_state.py
@@ -1,0 +1,75 @@
+import unittest
+from tap_intercom.sync import translate_state
+
+class TestTranslateState(unittest.TestCase):
+
+    def test_state_translation_for_old_format(self):
+        '''
+            Verify that state is translated to new format if old formatted state is provided
+        '''
+
+        state = {
+            "bookmarks": {
+                "companies": "2021-12-22T07:23:47.000000Z",
+                "company_segments": "2021-12-20T21:30:35.000000Z",
+                "conversations": "2021-12-22T08:01:05.000000Z",
+                "contacts": "2021-12-22T08:07:57.000000Z",
+                "segments": "2021-11-01T00:00:00Z"
+            }
+        }
+
+        expected_state = {
+            "bookmarks": {
+                "companies": {
+                    "updated_at": "2021-12-22T07:23:47.000000Z"
+                },
+                "company_segments": {
+                    "updated_at": "2021-12-20T21:30:35.000000Z"
+                },
+                "conversations": {
+                    "updated_at": "2021-12-22T08:01:05.000000Z"
+                },
+                "contacts": {
+                    "updated_at": "2021-12-22T08:07:57.000000Z"
+                },
+                "segments": {
+                    "updated_at": "2021-11-01T00:00:00Z"
+                }
+            }
+        }
+
+        new_state = translate_state(state)
+
+        # Verify that returned state is as expected with new format
+        self.assertEquals(new_state, expected_state)
+
+
+    def test_state_translate_for_new_format(self):
+        '''
+            Verify that state remain same if new formatted state is provided
+        '''
+
+        new_format_state = {
+            "bookmarks": {
+                "companies": {
+                    "updated_at": "2021-12-22T07:23:47.000000Z"
+                },
+                "company_segments": {
+                    "updated_at": "2021-12-20T21:30:35.000000Z"
+                },
+                "conversations": {
+                    "updated_at": "2021-12-22T08:01:05.000000Z"
+                },
+                "contacts": {
+                    "updated_at": "2021-12-22T08:07:57.000000Z"
+                },
+                "segments": {
+                    "updated_at": "2021-11-01T00:00:00Z"
+                }
+            }
+        }
+
+        new_state = translate_state(new_format_state)
+
+        # Verify that returned state is same for new formatted state
+        self.assertEquals(new_state, new_format_state)


### PR DESCRIPTION
# Description of change
[TDL-16981](https://jira.talendforge.org/browse/TDL-16981): Fix 'str' has no attribute get for getting bookmark
- Added translate_state method which will transform the state to a newer format before every sync.
**NOTE**: _Companies_ stream is changed from incremental to full_table so the old connection should have state for it so while transforming it to a newer format we kept the replication key the same as before in the bookmark because it's full_table now so no replication key for it now.


# Manual QA steps
 - Verified sync mode by providing state in an old format and it worked as expected.
 - Verified sync mode by providing state in a new format and it worked as expected
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
