### PR TITLE
Bump version to fix 1.1.4 issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## 1.1.5
+ * Fix 'str' has no attribute get for getting bookmark. This is a fix for the previous version 1.1.4 which was rolled back  [#38] (https://github.com/singer-io/tap-intercom/pull/38)
 
 ## 1.1.4
   * Request Timeout Implementation [#36](https://github.com/singer-io/tap-intercom/pull/36)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='1.1.4',
+      version='1.1.5',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],


### PR DESCRIPTION
# Description of change
Fix 'str' has no attribute get for getting bookmark. This is a fix for the previous version 1.1.4 which was rolled back

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
