### PR TITLE
TDL-17000: fix breaking changes

### DIFF
--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -65,8 +65,10 @@ class BaseStream:
 
     @staticmethod
     def epoch_milliseconds_to_dt_str(timestamp: float) -> str:
-        dt_object = datetime.datetime.fromtimestamp(timestamp / 1000.0)
-        return dt_object.isoformat()
+        with Transformer(integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) \
+            as transformer:
+            new_dttm = transformer._transform_datetime(timestamp)
+        return new_dttm
 
     @staticmethod
     def dt_to_epoch_seconds(dt_object: datetime) -> float:
@@ -125,7 +127,7 @@ class IncrementalStream(BaseStream):
                                                     stream_schema,
                                                     integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING,
                                                     metadata=stream_metadata)
-                    singer.write_record(self.tap_stream_id, transformed_record)
+                    singer.write_record(self.tap_stream_id, transformed_record, time_extracted=singer.utils.now())
                     counter.increment()
                     max_datetime = max(record_datetime, max_datetime)
             bookmark_date = singer.utils.strftime(max_datetime)
@@ -175,7 +177,7 @@ class FullTableStream(BaseStream):
                                                 stream_schema,
                                                 integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING,
                                                 metadata=stream_metadata)
-                singer.write_record(self.tap_stream_id, transformed_record)
+                singer.write_record(self.tap_stream_id, transformed_record, time_extracted=singer.utils.now())
                 counter.increment()
 
         return state

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -348,11 +348,19 @@ class Conversations(IncrementalStream):
             'pagination': {
                 'per_page': self.per_page
             },
-            "query": {
-                "field": self.replication_key,
-                "operator": ">",
-                "value": self.dt_to_epoch_seconds(bookmark_datetime)
-            },
+            'query': {
+                'operator': 'OR',
+                'value': [{
+                    'field': self.replication_key,
+                    'operator': '>',
+                    'value': self.dt_to_epoch_seconds(bookmark_datetime)
+                    },
+                    {
+                    'field': self.replication_key,
+                    'operator': '=',
+                    'value': self.dt_to_epoch_seconds(bookmark_datetime)
+                    }]
+                },
             "sort": {
                 "field": self.replication_key,
                 "order": "ascending"

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -65,8 +65,7 @@ class BaseStream:
 
     @staticmethod
     def epoch_milliseconds_to_dt_str(timestamp: float) -> str:
-        with Transformer(integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) \
-            as transformer:
+        with Transformer(integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as transformer:
             new_dttm = transformer._transform_datetime(timestamp)
         return new_dttm
 

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -65,6 +65,7 @@ class BaseStream:
 
     @staticmethod
     def epoch_milliseconds_to_dt_str(timestamp: float) -> str:
+        # Convert epoch milliseconds to datetime object in UTC format
         with Transformer(integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING) as transformer:
             new_dttm = transformer._transform_datetime(timestamp)
         return new_dttm
@@ -126,6 +127,7 @@ class IncrementalStream(BaseStream):
                                                     stream_schema,
                                                     integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING,
                                                     metadata=stream_metadata)
+                    # Write records with time_extracted field
                     singer.write_record(self.tap_stream_id, transformed_record, time_extracted=singer.utils.now())
                     counter.increment()
                     max_datetime = max(record_datetime, max_datetime)
@@ -176,6 +178,7 @@ class FullTableStream(BaseStream):
                                                 stream_schema,
                                                 integer_datetime_fmt=UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING,
                                                 metadata=stream_metadata)
+                # Write records with time_extracted field
                 singer.write_record(self.tap_stream_id, transformed_record, time_extracted=singer.utils.now())
                 counter.increment()
 

--- a/tests/unittests/test_epoch_to_dt_transform.py
+++ b/tests/unittests/test_epoch_to_dt_transform.py
@@ -1,0 +1,16 @@
+import unittest
+from tap_intercom.streams import BaseStream
+
+class TestEpochToDatetimeTransform(unittest.TestCase):
+
+    def test_epoch_milliseconds_to_dt_str(self):
+        """
+            Verify one epoch time with expected UTC datetime 
+        """
+        test_epoch = 1640760200000
+        expected_utc_datetime = "2021-12-29T06:43:20.000000Z" # expected UTC for `1640760200000`
+
+        datetime_str = BaseStream.epoch_milliseconds_to_dt_str(test_epoch)
+
+        # Verify that test epoch time is converted to valid UTC datetime
+        self.assertEquals(datetime_str, expected_utc_datetime)


### PR DESCRIPTION
# Description of change
[TDL-17000](https://jira.talendforge.org/browse/TDL-17000): fix breaking changes
- Updated epoch_milliseconds_to_dt_str() function to convert epoch to UTC time.
- Added time_extracted to write_record function.
- Updated search query for conversation stream to consider records greater or equal to bookmark from API. As the last stable version, 1.1.3 was considered records with the same replication key and bookmark value.

# Manual QA steps
 - Verified that bookmark is written in UTC timestamp.
- Verified that all records are emitted with time_extracted field.

 
# Risks
 - 
 
# Rollback steps
 - revert this branch
