### PR TITLE
remove build_daily, replaced with pipeline trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,14 +42,3 @@ workflows:
     jobs:
       - build:
           context: circleci-user
-  build_daily:
-    triggers:
-      - schedule:
-          cron: "0 14 * * *"
-          filters:
-            branches:
-              only:
-                - master
-    jobs:
-      - build:
-          context: circleci-user


### PR DESCRIPTION
# Description of change
Remove build_daily workflow. The commit workflow will be ran via pipeline trigger once per day.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
