### PR TITLE
TDL-19860: Need to update Primary keys for Company_Attributes & Contacts streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This tap:
 [company_attributes](https://developers.intercom.com/intercom-api-reference/reference#list-company-data-attributes)
 reference#list-customer-data-attributes)
 - Endpoint: https://api.intercom.io/data_attributes/company
-- Primary key fields: name
+- Primary key fields: _sdc_record_hash ie. the hash of [id, name, description]
 - Foreign key fields: none
 - Replication strategy: FULL_TABLE
 - Transformations: none
@@ -76,7 +76,7 @@ reference#list-customer-data-attributes)
 
 [customer_attributes](https://developers.intercom.com/intercom-api-reference/reference#list-customer-data-attributes)
 - Endpoint: https://api.intercom.io/data_attributes/customer
-- Primary key fields: name
+- Primary key fields: _sdc_record_hash ie. the hash of [id, name, description]
 - Foreign key fields: none
 - Replication strategy: FULL_TABLE
 - Transformations: none

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(name='tap-intercom',
               'pylint',
               'ipdb',
               'nose',
+              'parameterized'
           ]
       }
       )

--- a/tap_intercom/schemas/company_attributes.json
+++ b/tap_intercom/schemas/company_attributes.json
@@ -58,6 +58,9 @@
     "updated_at": {
       "type": ["null", "string"],
       "format": "date-time"
+    },
+    "_sdc_record_hash": {
+      "type": ["null", "string"]
     }
   }
 }

--- a/tap_intercom/schemas/contact_attributes.json
+++ b/tap_intercom/schemas/contact_attributes.json
@@ -99,6 +99,12 @@
         "string"
       ],
       "format": "date-time"
+    },
+    "_sdc_record_hash": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   }
 }

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -226,6 +226,10 @@ class FullTableStream(BaseStream):
 
             LOGGER.info("FINISHED Syncing: {}, total_records: {}.".format(self.tap_stream_id, counter.value))
 
+        # Write activate version after syncing
+        if sync_with_version:
+            singer.write_message(activate_version_message)
+
         return state
 
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -72,7 +72,7 @@ class IntercomBaseTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"}
             },
             "company_attributes": {
-                self.PRIMARY_KEYS: {"name"},
+                self.PRIMARY_KEYS: {"_sdc_record_hash"},
                 self.REPLICATION_METHOD: self.FULL_TABLE
             },
             "company_segments": {
@@ -91,7 +91,7 @@ class IntercomBaseTest(unittest.TestCase):
                 self.REPLICATION_KEYS: {"updated_at"}
             },
             "contact_attributes": {
-                self.PRIMARY_KEYS: {"name"},
+                self.PRIMARY_KEYS: {"_sdc_record_hash"},
                 self.REPLICATION_METHOD: self.FULL_TABLE
             },
             "contacts": {

--- a/tests/test_intercom_automated_fields.py
+++ b/tests/test_intercom_automated_fields.py
@@ -54,7 +54,8 @@ class IntercomAutomaticFields(IntercomBaseTest):
 
                 # collect actual values
                 data = synced_records.get(stream, {})
-                record_messages_keys = [set(row.get('data').keys()) for row in data.get('messages', {})]
+                record_messages_keys = [set(row.get('data').keys()) for row in data.get('messages', {})
+                                        if data.get['messages']['action'] == 'upsert']
 
 
                 # Verify that you get some records for each stream

--- a/tests/test_intercom_automated_fields.py
+++ b/tests/test_intercom_automated_fields.py
@@ -55,7 +55,7 @@ class IntercomAutomaticFields(IntercomBaseTest):
                 # collect actual values
                 data = synced_records.get(stream, {})
                 record_messages_keys = [set(row.get('data').keys()) for row in data.get('messages', {})
-                                        if row.get['messages']['action'] == 'upsert']
+                                        if row['action'] == 'upsert']
 
 
                 # Verify that you get some records for each stream

--- a/tests/test_intercom_automated_fields.py
+++ b/tests/test_intercom_automated_fields.py
@@ -55,7 +55,7 @@ class IntercomAutomaticFields(IntercomBaseTest):
                 # collect actual values
                 data = synced_records.get(stream, {})
                 record_messages_keys = [set(row.get('data').keys()) for row in data.get('messages', {})
-                                        if data.get['messages']['action'] == 'upsert']
+                                        if row.get['messages']['action'] == 'upsert']
 
 
                 # Verify that you get some records for each stream

--- a/tests/unittests/test_sdc_record_hash.py
+++ b/tests/unittests/test_sdc_record_hash.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest import mock
+from parameterized import parameterized
+from tap_intercom.client import IntercomClient
+from tap_intercom.streams import Admins, BaseStream, CompanyAttributes, ContactAttributes
+
+def transform(*args, **kwargs):
+    return args[0]
+
+class TestSDCRecordHash(unittest.TestCase):
+    @parameterized.expand([
+        ['default_attr', {'name': 'test 1', 'description': 'test 1 description', 'label': 'test1'}],
+        ['default_attr_without_description', {'name': 'test 1', 'label': 'test1'}],
+        ['custom_attr', {'id': 11, 'name': 'test 1', 'description': 'test 1 description', 'label': 'test1'}],
+        ['custom_attr_without_description', {'id': 11, 'name': 'test 1', 'label': 'test1'}],
+    ])
+    def test_generate_hash(self, name, test_data):
+        client = IntercomClient('test_access_token', 300)
+        stream = BaseStream(client)
+        hashed_records = stream.generate_record_hash(test_data)
+
+        self.assertIsNotNone(hashed_records)
+        self.assertIsNotNone(hashed_records.get('_sdc_record_hash'))
+
+    @parameterized.expand([
+        ['company_attr', CompanyAttributes, True],
+        ['contact_attr', ContactAttributes, True],
+        ['admins', Admins, False],
+    ])
+    @mock.patch('singer.write_record')
+    @mock.patch('tap_intercom.streams.transform', side_effect = transform)
+    @mock.patch('tap_intercom.streams.CompanyAttributes.get_records', side_effect = [[{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]])
+    @mock.patch('tap_intercom.streams.ContactAttributes.get_records', side_effect = [[{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]])
+    @mock.patch('tap_intercom.streams.Admins.get_records', side_effect = [[{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]])
+    def test_sync_hashed(self, name, test_data, expected_data, mocked_admins_get_records, mocked_contacts_attr_get_records, mocked_company_attr_get_records, mocked_transform, mocked_write_record):
+        client = IntercomClient('test_access_token', 300)
+        stream = test_data(client)
+        stream.sync({}, {}, {}, {}, None)
+
+        write_record_calls = mocked_write_record.mock_calls
+
+        self.assertIsNotNone(write_record_calls)
+        for call in write_record_calls:
+            self.assertEqual(call[1][1].get('_sdc_record_hash') is not None, expected_data)

--- a/tests/unittests/test_sdc_record_hash.py
+++ b/tests/unittests/test_sdc_record_hash.py
@@ -15,6 +15,9 @@ class TestSDCRecordHash(unittest.TestCase):
         ['custom_attr_without_description', {'id': 11, 'name': 'test 1', 'label': 'test1'}],
     ])
     def test_generate_hash(self, name, test_data):
+        """
+            Test cases to verify we generate a hash of id, name and description and add it in the '_sdc_record_hash' field
+        """
         client = IntercomClient('test_access_token', 300)
         stream = BaseStream(client)
         hashed_records = stream.generate_record_hash(test_data)
@@ -34,6 +37,9 @@ class TestSDCRecordHash(unittest.TestCase):
     @mock.patch('tap_intercom.streams.ContactAttributes.get_records', side_effect = [[{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]])
     @mock.patch('tap_intercom.streams.Admins.get_records', side_effect = [[{'id': 1, 'name': 'test1'}, {'id': 2, 'name': 'test2'}]])
     def test_sync_hashed(self, name, test_data, expected_data, mocked_admins_get_records, mocked_contacts_attr_get_records, mocked_company_attr_get_records, mocked_transform, mocked_write_message, mocked_write_record):
+        """
+            Test cases to verify we generate hash of fields for company and contact attributes streams
+        """
         client = IntercomClient('test_access_token', 300)
         stream = test_data(client)
         stream.sync({}, {}, {}, {}, None)


### PR DESCRIPTION
# Description of change
TDL-19860: Need to update Primary keys for Company_Attributes & Contacts streams
- Updated the Primary Key for `company_attributes` and used the hash of `['id', 'name', 'description']` as the Primary Key.

**NOTE:** The `contact_attributes` is also using the same endpoint as the `company_attributes` thus, updated the Primary Key for contact_attributes as well.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
