### PR TITLE
Fix custom_attributes schema for conversations stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+ * Fix schema for Conversations custom_attributes field [#63](https://github.com/singer-io/tap-intercom/pull/63)
+
 ## 2.0.0
  * Update primary keys for company_attributes and contacts stream [#56](https://github.com/singer-io/tap-intercom/pull/56)
  * Update API version and related new fields [#53](https://github.com/singer-io/tap-intercom/pull/53)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='2.0.0',
+      version='2.0.1',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_intercom/schemas/conversations.json
+++ b/tap_intercom/schemas/conversations.json
@@ -874,20 +874,7 @@
         "null",
         "object"
       ],
-      "properties": {
-        "issue_type": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "priority": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      }
+      "additionalProperties": true
     }
   }
 }


### PR DESCRIPTION
# Description of change
The custom_attributes field does not have standard keys and the current schema is causing data to be dropped. 

Api docs: https://developers.intercom.com/intercom-api-reference/v2.5/reference/the-conversation-model
# Manual QA steps
 - tested with support customer data
 
# Risks
 - Low, the schema is broken for this field currently
 
# Rollback steps
 - revert this branch
