### PR TITLE
update conversations schema

### DIFF
--- a/tap_intercom/schemas/conversations.json
+++ b/tap_intercom/schemas/conversations.json
@@ -2,39 +2,6 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "assignee": {
-      "type": [
-        "null",
-        "object"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "id": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "type": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "name": {
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "email": {
-          "type": [
-            "null",
-            "string"
-          ]
-        }
-      }
-    },
     "source": {
       "type": [
         "null",


### PR DESCRIPTION
# Description of change
It is observed that `assignee` object is not getting populated as a response using API version 2.5. Hence, made the respective changes in `conversations` schema ([doc link](https://developers.intercom.com/docs/references/2.2/changelog/#maintain-conversation-context-with-both-team-and-admin-assignees))

Note : Integration test cases fixed in a separate PR #72

# Manual QA steps
 - Tested the changes by running discovery and sync
 
# Risks
 - low
 
# Rollback steps
 - revert this branch
