### PR TITLE
SAC-27423/companies sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,no-self-use,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding
+	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -434,6 +434,7 @@ class Companies(IncrementalStream):
         scrolling = True
         params = {}
         LOGGER.info("Syncing: {}".format(self.tap_stream_id))
+        records = []
 
         while True:
             try:

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -12,7 +12,7 @@ import singer
 from singer import Transformer, metrics, metadata, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.transform import transform, unix_milliseconds_to_datetime
 
-from tap_intercom.client import (IntercomClient, IntercomError)
+from tap_intercom.client import (IntercomClient, IntercomError, IntercomNotFoundError)
 from tap_intercom.transform import (transform_json, transform_times, find_datetimes_in_schema)
 
 LOGGER = singer.get_logger()
@@ -236,13 +236,13 @@ class IncrementalStream(BaseStream):
         max_datetime = sync_start_date
         # We are not using singer's record counter as the counter reset after 60 seconds
         record_counter = 0
-
+        all_counter = 0
         schema_datetimes = find_datetimes_in_schema(stream_schema)
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             for record in self.get_records(sync_start_date, stream_metadata=stream_metadata):
                 # In case of interrupted sync, skip records last synced conversations
-
+                all_counter += 1
                 transform_times(record, schema_datetimes)
 
                 record_datetime = singer.utils.strptime_to_utc(
@@ -276,8 +276,11 @@ class IncrementalStream(BaseStream):
                     # Reset counter
                     record_counter = 0
 
+                if all_counter % 1000 == 0:
+                    LOGGER.info("Still Syncing: {}, total_records written so far: {}. total seen {}".format(self.tap_stream_id, record_counter, all_counter))
+
             bookmark_date = singer.utils.strftime(max_datetime)
-            LOGGER.info("FINISHED Syncing: {}, total_records: {}.".format(self.tap_stream_id, counter.value))
+            LOGGER.info("FINISHED Syncing: {}, total_records: {}.".format(self.tap_stream_id, record_counter))
 
         LOGGER.info("Stream: {}, writing final bookmark".format(self.tap_stream_id))
         self.write_bookmark(state, bookmark_date)
@@ -432,8 +435,12 @@ class Companies(IncrementalStream):
         params = {}
         LOGGER.info("Syncing: {}".format(self.tap_stream_id))
 
-        while scrolling:
-            response = self.client.get(self.path, params=params)
+        while True:
+            try:
+                response = self.client.get(self.path, params=params)
+            except IntercomNotFoundError as err:
+                LOGGER.info("Synced last page: {}, records: {}".format(self.tap_stream_id, len(records)))
+                break
 
             if response.get(self.data_key) is None:
                 LOGGER.warning('response is empty for "{}" stream'.format(self.tap_stream_id))
@@ -442,12 +449,10 @@ class Companies(IncrementalStream):
             LOGGER.info("Synced: {}, records: {}".format(self.tap_stream_id, len(records)))
 
             # stop scrolling if 'data' array is empty
-            if 'scroll_param' in response and response.get(self.data_key):
+            if len(records) > 0:
                 scroll_param = response.get('scroll_param')
                 params = {'scroll_param': scroll_param}
                 LOGGER.info("Syncing next page")
-            else:
-                scrolling = False
 
             yield from records
 
@@ -487,7 +492,7 @@ class CompanyAttributes(FullTableStream):
             yield from response.get(self.data_key,  [])
 
 
-class CompnaySegments(IncrementalStream):
+class CompanySegments(IncrementalStream):
     """
     Retrieve company segments
 
@@ -897,7 +902,7 @@ STREAMS = {
     "admins": Admins,
     "companies": Companies,
     "company_attributes": CompanyAttributes,
-    "company_segments": CompnaySegments,
+    "company_segments": CompanySegments,
     "conversations": Conversations,
     "conversation_parts": ConversationParts,
     "contact_attributes": ContactAttributes,

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -2,7 +2,7 @@ import unittest
 import singer
 import datetime as dt
 from unittest import mock
-from tap_intercom.client import IntercomClient, IntercomError
+from tap_intercom.client import IntercomClient, IntercomError, IntercomNotFoundError
 from parameterized import parameterized
 from tap_intercom.streams import AdminList, BaseStream, Admins,Companies, CompanyAttributes, Contacts, ContactAttributes, CompanySegments, Conversations, Segments, Tags, Teams, ConversationParts
 
@@ -10,7 +10,7 @@ class TestData(unittest.TestCase):
 
     base_client = IntercomClient("test","300")
     @parameterized.expand([
-        ['Companies',[Companies, [{'data':'', 'scroll_param':''},{'data':''}]], []],
+        ['Companies',[Companies, IntercomNotFoundError()], []],
         ['CompanyAttributes',[CompanyAttributes, [{'data':['test1'],'pages':{'next':'abc'}},{'data':['test2'],'pages':{'next':''}}]],['test1','test2']],
         ['CompanySegments',[CompanySegments,[{'segments':['test1'],'pages':{'next':'abc'}},{'segments':['test2'],'pages':{'next':''}}]],['test1','test2']],
         ['Segments',[Segments,[{'segments':['test1'],'pages':{'next':'abc'}},{'segments':['test2'],'pages':{'next':''}}]],['test1','test2']],

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -4,15 +4,15 @@ import datetime as dt
 from unittest import mock
 from tap_intercom.client import IntercomClient, IntercomError
 from parameterized import parameterized
-from tap_intercom.streams import AdminList, BaseStream, Admins,Companies, CompanyAttributes,Contacts, ContactAttributes,CompnaySegments, Conversations, Segments, Tags, Teams,ConversationParts
+from tap_intercom.streams import AdminList, BaseStream, Admins,Companies, CompanyAttributes, Contacts, ContactAttributes, CompanySegments, Conversations, Segments, Tags, Teams, ConversationParts
 
 class TestData(unittest.TestCase):
-    
+
     base_client = IntercomClient("test","300")
     @parameterized.expand([
         ['Companies',[Companies, [{'data':'', 'scroll_param':''},{'data':''}]], []],
         ['CompanyAttributes',[CompanyAttributes, [{'data':['test1'],'pages':{'next':'abc'}},{'data':['test2'],'pages':{'next':''}}]],['test1','test2']],
-        ['CompanySegments',[CompnaySegments,[{'segments':['test1'],'pages':{'next':'abc'}},{'segments':['test2'],'pages':{'next':''}}]],['test1','test2']],
+        ['CompanySegments',[CompanySegments,[{'segments':['test1'],'pages':{'next':'abc'}},{'segments':['test2'],'pages':{'next':''}}]],['test1','test2']],
         ['Segments',[Segments,[{'segments':['test1'],'pages':{'next':'abc'}},{'segments':['test2'],'pages':{'next':''}}]],['test1','test2']],
         ['ContactAttributes',[ContactAttributes,[{'data':['test1'],'pages':{'next':'abc'}},{'data':['test2'],'pages':{'next':''}}]],['test1','test2']],
         ['Tags',[Tags,[{'data':['test1'],'pages':{'next':'abc'}},{'data':['test2'],'pages':{'next':''}}]],['test1','test2']],
@@ -24,13 +24,13 @@ class TestData(unittest.TestCase):
         """
         Verify get_records for stream
         """
-        
+
         test_stream = data[0](self.base_client, None, [])
         mocked_client.side_effect = data[1]
 
         test_data = list(test_stream.get_records())
         self.assertEqual(test_data,expected_data)
-    
+
     @mock.patch("tap_intercom.streams.Admins.get_parent_data")
     @mock.patch("tap_intercom.client.IntercomClient.get")
     def test_admin_get_records(self,mocked_client,mocked_parent_data):
@@ -38,15 +38,15 @@ class TestData(unittest.TestCase):
         Verify get_records for Admin stream
         """
         test_stream = Admins(self.base_client, None, ['admins'])
-        
+
         mocked_parent_data.return_value = ['id']
         mocked_client.return_value = 'test'
-        
+
         parent_data = list(test_stream.get_records())
         expected_data = ['test']
-        
+
         self.assertEqual(parent_data,expected_data)
-    
+
     def test_dt_to_epoch(self):
         """
             Verify expected epoch time with UTC datetime
@@ -58,7 +58,7 @@ class TestData(unittest.TestCase):
         test_epoch = BaseStream.dt_to_epoch_seconds(converted_datetime)
 
         self.assertEqual(test_epoch,expected_epoch)
-    
+
     @mock.patch("tap_intercom.client.IntercomClient.get")
     @mock.patch("tap_intercom.streams.LOGGER.critical")
     def test_admin_list_get_records(self,mocked_logger,mocked_client):
@@ -66,14 +66,14 @@ class TestData(unittest.TestCase):
         Verify get_records for AdminList
         """
         test_stream = AdminList(self.base_client, None, ['admin_list'])
-        
+
         mocked_client.return_value = {}
-        
+
         with self.assertRaises(IntercomError) as e:
             list(test_stream.get_records())
-        
+
         self.assertEqual(mocked_logger.call_count,1)
-    
+
     @mock.patch("tap_intercom.client.IntercomClient.post",side_effect =[{'data':[{'key': 'value', 'tags': {}, 'companies': {}}],'pages':{'next':''}}])
     @mock.patch("tap_intercom.streams.BaseStream.dt_to_epoch_seconds")
     def test_contacts_get_records(self,mocked_time,mocked_client):
@@ -84,11 +84,11 @@ class TestData(unittest.TestCase):
 
         test_data = list(test_stream.get_records(stream_metadata={}))
         expected_data = [{'key': 'value'}]
-        
+
         self.assertEqual(test_data,expected_data)
-    
+
 class TestFullTable(unittest.TestCase):
-        
+
     base_client = IntercomClient("test","300")
 
     @mock.patch("tap_intercom.transform.find_datetimes_in_schema")


### PR DESCRIPTION
# Description of change
Adds:
- Extra logging for `IncrementalStream`, but only after every 1,000 records so it's not too noisy

Fixes:
- a `pylint` error where `no-self-use` is now optional and does not need to be disabled
- `CompnaySegments` to be named `CompanySegments`

The main change is to the `Companies` stream. Before the pagination logic was looking for an empty page in order to stop asking for more records. Now, we look for a 404 response.

# Manual QA steps
 - Ran the tap
 
# Risks
 - The 404 response is an undocumented part of the Intercom API. But we've seen the pattern of full-page (100 records), partial-page (1-99 records), and the 404 over and over in testing
 - See the attached screenshot
   > If the end of the scroll is reached, "companies" will be empty and the scroll parameter will expire

   - `"companies"` is not even a key on the response, so these docs can't be trusted anyway

![CleanShot 2025-04-28 at 11 05 19@2x](https://github.com/user-attachments/assets/17ca1ba7-98dc-4928-b172-01bec41b2683)
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
