### PR TITLE
fix: 'conversation_parts.assigned_to' property is an object

### DIFF
--- a/tap_intercom/schemas/conversation_parts.json
+++ b/tap_intercom/schemas/conversation_parts.json
@@ -5,8 +5,19 @@
     "assigned_to": {
       "type": [
         "null",
-        "string"
-      ]
+        "object"
+      ],
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
     },
     "attachments": {
       "anyOf": [


### PR DESCRIPTION


# Description of change

Updated the 'conversation_parts.assigned_to' property to accept an object type in the JSON schema.

The current implementation assumes it is a string, leading to a weird Python Dict representation in the target database:
<img width="334" height="305" alt="image" src="https://github.com/user-attachments/assets/35dd8333-3485-4b2b-a631-69ca1ccfc785" />


https://developers.intercom.com/docs/references/2.12/rest-api/api.intercom.io/conversations/retrieveconversation
<img width="692" height="275" alt="image" src="https://github.com/user-attachments/assets/26021880-9a0d-4b70-9f5c-282e351755a7" />


# Manual QA steps
 - 
 
# Risks
 - Breaking current users relying on this field format
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
