### PR TITLE
SAC-30973: Exclude un-auth streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,15 @@ jobs:
           name: 'Unit Tests'
           command: |
             source /usr/local/share/virtualenvs/tap-intercom/bin/activate
-            coverage run -m pytest tests/unittests
+            coverage run --source=tap_intercom -m pytest tests/unittests
             coverage html
+      - run:
+          name: 'Coverage Report'
+          command: |
+            source /usr/local/share/virtualenvs/tap-intercom/bin/activate
+            coverage report -m --fail-under=99
       - store_test_results:
-          path: test_output/report.xml
+          path: test_output
       - store_artifacts:
           path: htmlcov
       - add_ssh_keys

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.3.0
+  * Exclude un-authorised streams from catalog during discovery.[#91](https://github.com/singer-io/tap-intercom/pull/91)
+
 ## 2.2.4
   * Fix interrupted bookmarking for conversations [#85](https://github.com/singer-io/tap-intercom/pull/85)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 .DEFAULT_GOAL := test
 
 test:
-	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding,too-many-positional-arguments,broad-exception-raised
+	pylint tap_intercom --disable missing-docstring,logging-format-interpolation,no-member,arguments-differ,too-few-public-methods,line-too-long,too-many-arguments,too-many-locals,useless-object-inheritance,simplifiable-if-statement,protected-access,chained-comparison,inconsistent-return-statements,redefined-builtin,too-many-statements,too-many-nested-blocks,unused-variable,no-else-return,consider-using-f-string,unspecified-encoding,too-many-positional-arguments,broad-exception-raised,too-many-lines

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-intercom',
-      version='2.2.4',
+      version='2.3.0',
       description='Singer.io tap for extracting data from the Intercom API',
       author='jeff.huth@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_intercom/__init__.py
+++ b/tap_intercom/__init__.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 
 import singer
-from tap_intercom.client import IntercomClient
 from singer import utils
 
+from tap_intercom.client import IntercomClient
 from tap_intercom.discover import discover
 from tap_intercom.sync import sync
 

--- a/tap_intercom/__init__.py
+++ b/tap_intercom/__init__.py
@@ -4,7 +4,7 @@ import singer
 from singer import utils
 
 from tap_intercom.client import IntercomClient
-from tap_intercom.discover import discover
+from tap_intercom.discover import discover as _discover
 from tap_intercom.sync import sync
 
 LOGGER = singer.get_logger()
@@ -19,7 +19,7 @@ REQUIRED_CONFIG_KEYS = [
 def do_discover(client: IntercomClient):
 
     LOGGER.info('Starting discover')
-    catalog = discover(client=client)
+    catalog = _discover(client=client)
     catalog.dump()
     LOGGER.info('Finished discover')
 
@@ -46,8 +46,9 @@ def main():
             if parsed_args.catalog:
                 catalog = parsed_args.catalog
             else:
-                catalog = discover(client=client)
+                catalog = _discover(client=client)
             sync(parsed_args.config, parsed_args.state, catalog)
 
-if __name__ == '__main__':
+
+if __name__ == '__main__':  # pragma: no cover
     main()

--- a/tap_intercom/__init__.py
+++ b/tap_intercom/__init__.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 
 import singer
-
+from tap_intercom.client import IntercomClient
 from singer import utils
+
 from tap_intercom.discover import discover
 from tap_intercom.sync import sync
 
@@ -14,10 +15,11 @@ REQUIRED_CONFIG_KEYS = [
     'user_agent'
 ]
 
-def do_discover():
+
+def do_discover(client: IntercomClient):
 
     LOGGER.info('Starting discover')
-    catalog = discover()
+    catalog = discover(client=client)
     catalog.dump()
     LOGGER.info('Finished discover')
 
@@ -30,16 +32,22 @@ def main():
     # Parse command line arguments
     parsed_args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-    # If discover flag was passed, run discovery mode and dump output to stdout
-    if parsed_args.discover:
-        do_discover()
-    # Otherwise run in sync mode
-    else:
-        if parsed_args.catalog:
-            catalog = parsed_args.catalog
+    # Use the Intercom client as a context manager which makes sure __enter__ is called to check the creds
+    with IntercomClient(
+        access_token=parsed_args.config["access_token"],
+        user_agent=parsed_args.config.get("user_agent"),
+        config_request_timeout=parsed_args.config.get("request_timeout")
+    ) as client:
+        # If discover flag was passed, run discovery mode and dump output to stdout
+        if parsed_args.discover:
+            do_discover(client=client)
+        # Otherwise run in sync mode
         else:
-            catalog = discover()
-        sync(parsed_args.config, parsed_args.state, catalog)
+            if parsed_args.catalog:
+                catalog = parsed_args.catalog
+            else:
+                catalog = discover(client=client)
+            sync(parsed_args.config, parsed_args.state, catalog)
 
 if __name__ == '__main__':
     main()

--- a/tap_intercom/client.py
+++ b/tap_intercom/client.py
@@ -329,6 +329,6 @@ class IntercomClient(object):
         return self.get(path, **kwargs)
 
     def probe_stream(self, path, http_method='GET', **kwargs):
-        if http_method == 'POST':
+        if http_method.upper() == 'POST':
             return self.post(path, **kwargs)
         return self.get(path, **kwargs)

--- a/tap_intercom/client.py
+++ b/tap_intercom/client.py
@@ -327,3 +327,8 @@ class IntercomClient(object):
         if method=='POST':
             return self.post(path, **kwargs)
         return self.get(path, **kwargs)
+
+    def probe_stream(self, path, http_method='GET', **kwargs):
+        if http_method == 'POST':
+            return self.post(path, **kwargs)
+        return self.get(path, **kwargs)

--- a/tap_intercom/discover.py
+++ b/tap_intercom/discover.py
@@ -1,4 +1,6 @@
 from singer.catalog import Catalog
+
+from tap_intercom.client import IntercomClient
 from tap_intercom.schema import get_schemas
 
 
@@ -8,11 +10,13 @@ def _get_key_properties_from_meta(schema_meta: list) -> str:
     """
     return schema_meta[0].get('metadata').get('table-key-properties')
 
+
 def _get_replication_method_from_meta(schema_meta: list) -> str:
     """
     Gets the forced-replication-method from the schema metadata.
     """
     return schema_meta[0].get('metadata').get('forced-replication-method')
+
 
 def _get_replication_key_from_meta(schema_meta: list) -> str:
     """
@@ -22,11 +26,12 @@ def _get_replication_key_from_meta(schema_meta: list) -> str:
         return schema_meta[0].get('metadata').get('valid-replication-keys')[0]
     return None
 
-def discover():
+
+def discover(client: IntercomClient):
     """
     Constructs a singer Catalog object based on the schemas and metadata.
     """
-    schemas, field_metadata = get_schemas()
+    schemas, field_metadata = get_schemas(client=client)
     streams = []
 
     for schema_name, schema in schemas.items():

--- a/tap_intercom/discover.py
+++ b/tap_intercom/discover.py
@@ -1,7 +1,11 @@
+import singer
 from singer.catalog import Catalog
 
-from tap_intercom.client import IntercomClient
+from tap_intercom.client import IntercomClient, IntercomForbiddenError
 from tap_intercom.schema import get_schemas
+from tap_intercom.streams import STREAMS
+
+LOGGER = singer.get_logger()
 
 
 def _get_key_properties_from_meta(schema_meta: list) -> str:
@@ -27,11 +31,80 @@ def _get_replication_key_from_meta(schema_meta: list) -> str:
     return None
 
 
-def discover(client: IntercomClient):
+def _prune_inaccessible_children(schemas: dict, field_metadata: dict) -> None:
+    """
+    Remove child streams from the catalog whose parent stream was excluded.
+
+    A child is pruned only when its parent is a replicable stream
+    (to_replicate=True) that is absent from schemas, meaning it was removed
+    due to an access failure.  Children of non-replicable helper streams
+    (e.g. AdminList) are intentionally skipped.
+
+    Mutates schemas and field_metadata in place.
+    """
+    for name, stream_cls in list(STREAMS.items()):
+        parent = stream_cls.parent
+        if (name in schemas
+                and parent is not None
+                and getattr(parent, 'to_replicate', True)
+                and parent.tap_stream_id not in schemas):
+            LOGGER.warning(
+                "Stream '%s' excluded from catalog because its parent "
+                "stream '%s' is not accessible.",
+                name, parent.tap_stream_id,
+            )
+            schemas.pop(name)
+            field_metadata.pop(name)
+
+
+def _apply_access_checks(
+    client: IntercomClient, schemas: dict, field_metadata: dict
+) -> None:
+    """
+    Probe each stream for read access and remove inaccessible streams
+    (and their children) from schemas and field_metadata in place.
+
+    Raises IntercomForbiddenError if no streams remain in the catalog after
+    access checks, since discovery would produce a useless empty catalog.
+    """
+    inaccessible_streams = [
+        stream_name
+        for stream_name, stream_cls in STREAMS.items()
+        if stream_name in schemas
+        and not stream_cls(client=client).check_access()
+    ]
+
+    for stream_name in inaccessible_streams:
+        schemas.pop(stream_name, None)
+        field_metadata.pop(stream_name, None)
+
+    _prune_inaccessible_children(schemas, field_metadata)
+
+    if not schemas:
+        raise IntercomForbiddenError(
+            "HTTP-error-code: 403, Error: The account credentials supplied "
+            "do not have 'read' access to any of the streams supported by "
+            "the tap. Data collection cannot be initiated due to lack of "
+            "permissions."
+        )
+
+    if inaccessible_streams:
+        LOGGER.warning(
+            "Unauthorised streams excluded from catalog: %s",
+            ", ".join(inaccessible_streams),
+        )
+
+
+def discover(client: IntercomClient) -> Catalog:
     """
     Constructs a singer Catalog object based on the schemas and metadata.
+
+    Access to each stream is verified using the provided client; streams the
+    credentials cannot read are excluded from the returned catalog.
     """
-    schemas, field_metadata = get_schemas(client=client)
+    schemas, field_metadata = get_schemas()
+    _apply_access_checks(client, schemas, field_metadata)
+
     streams = []
 
     for schema_name, schema in schemas.items():

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -1,15 +1,67 @@
-import os
 import json
-from singer import metadata
+import os
+
+from singer import get_logger, metadata
+
+from tap_intercom.client import IntercomClient, IntercomError
 from tap_intercom.streams import STREAMS
+
+LOGGER = get_logger()
 
 # Reference:
 # https://github.com/singer-io/getting-started/blob/master/docs/DISCOVERY_MODE.md#Metadata
 
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
-def get_schemas():
+
+def prune_inaccessible_children(schemas, field_metadata, inaccessible_streams):
+    """ Function to check the schemas having any child stream whose parent is not accessible
+    """
+    for stream_name, stream_obj in STREAMS.items():
+        if stream_obj.parent and stream_obj.parent.tap_stream_id in inaccessible_streams:
+            if stream_name in schemas:
+                del schemas[stream_name]
+            if stream_name in field_metadata:
+                del field_metadata[stream_name]
+
+
+def check_stream_access(client: IntercomClient, stream_obj):
+    """
+    Checks if the stream is accessible with the provided credentials by making a test API call to the endpoint.
+    If the stream is not accessible, then raises an exception which will be caught in the main function and logged.
+    """
+    stream_name = stream_obj.tap_stream_id
+
+    # Get the specific details from the stream object.
+    path = stream_obj.path
+    params = stream_obj.params if hasattr(stream_obj, 'params') else {}
+    json_body = {}
+    # Default to GET if probe_http_method is not defined in the stream object
+    probe_http_method = getattr(stream_obj, 'probe_http_method', 'GET').upper()
+
+    has_parent = stream_obj.parent is not None
+    if has_parent:
+        # If the stream has a parent stream, then it's access depends on the parent stream's access.
+        parent_stream_name = stream_obj.parent.tap_stream_id
+        LOGGER.info("Stream {} has parent stream {}. Access depends on parent stream.".format(stream_name, parent_stream_name))
+        return True
+
+    if probe_http_method == "POST":  # Update the json with the probe_search_query
+        json_body = stream_obj.probe_search_query
+
+    try:
+        LOGGER.info("Checking access for stream: {}".format(stream_name))
+        client.probe_stream(path, http_method=probe_http_method, params=params, json=json_body)
+        LOGGER.info("Stream {} is accessible".format(stream_name))
+        return True
+    except IntercomError as e:
+        LOGGER.error("Stream {} is not accessible. Error: {}".format(stream_name, str(e)))
+        return False
+
+
+def get_schemas(client: IntercomClient):
     """
     Loads the schemas defined for the tap.
 
@@ -20,9 +72,24 @@ def get_schemas():
     schemas = {}
     field_metadata = {}
 
+    inaccessible_streams = []
+
     for stream_name, stream_object in STREAMS.items():
         replication_ind = stream_object.to_replicate
         if replication_ind:
+            # Check if the stream is a child streams and it's parent stream is inaccessible,
+            # then mark the stream as inaccessible without checking access for the child stream.
+            if stream_object.parent and stream_object.parent.tap_stream_id in inaccessible_streams:
+                inaccessible_streams.append(stream_name)
+                LOGGER.warning("Stream {} is a child stream and its parent stream {} is inaccessible,"
+                               " hence marking stream {} as inaccessible".format(stream_name, stream_object.parent.tap_stream_id, stream_name))
+                continue
+
+            # Check stream access
+            if not check_stream_access(client, stream_object):
+                inaccessible_streams.append(stream_name)
+                continue
+
             schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
             with open(schema_path) as file:
                 schema = json.load(file)
@@ -51,5 +118,16 @@ def get_schemas():
             mdata = metadata.to_list(mdata)
 
             field_metadata[stream_name] = mdata
+
+    # check if any child stream whose parent is not accessible is still in schemas
+    prune_inaccessible_children(schemas, field_metadata, inaccessible_streams)
+
+    if not schemas:  # Raise error if none of the streams were added in schemas.
+        error_msg = "No accessible streams found with the provided credentials. Please check the configuration."
+        LOGGER.error(error_msg)
+        raise IntercomError(error_msg)
+
+    if inaccessible_streams:
+        LOGGER.warning("The following streams were found to be inaccessible and have been excluded: {}".format(", ".join(inaccessible_streams)))
 
     return schemas, field_metadata

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -82,7 +82,7 @@ def get_schemas(client: IntercomClient):
             if stream_object.parent and stream_object.parent.tap_stream_id in inaccessible_streams:
                 inaccessible_streams.append(stream_name)
                 LOGGER.warning("Stream {} is a child stream and its parent stream {} is inaccessible,"
-                               " hence marking stream {} as inaccessible".format(stream_name, stream_object.parent.tap_stream_id, stream_name))
+                               " hence marking stream as inaccessible".format(stream_name, stream_object.parent.tap_stream_id))
                 continue
 
             # Check stream access

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -3,9 +3,6 @@ import os
 
 from singer import get_logger, metadata
 
-from tap_intercom.client import (IntercomClient, IntercomForbiddenError,
-                                 IntercomScrollExistsError,
-                                 IntercomUnauthorizedError)
 from tap_intercom.streams import STREAMS
 
 LOGGER = get_logger()
@@ -18,59 +15,7 @@ def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
 
-def prune_inaccessible_children(schemas, field_metadata, inaccessible_streams):
-    """ Function to check the schemas having any child stream whose parent is not accessible
-    """
-    for stream_name, stream_obj in STREAMS.items():
-        if stream_obj.parent and stream_obj.parent.tap_stream_id in inaccessible_streams:
-            if stream_name in schemas:
-                del schemas[stream_name]
-            if stream_name in field_metadata:
-                del field_metadata[stream_name]
-
-
-def check_stream_access(client: IntercomClient, stream_obj):
-    """
-    Checks if the stream is accessible with the provided credentials by making a test API call to the endpoint.
-    Returns True if the stream is accessible, False if not (catches IntercomError internally and logs it).
-    """
-    stream_name = stream_obj.tap_stream_id
-
-    # Get the specific details from the stream object.
-    path = stream_obj.path
-    params = stream_obj.params if hasattr(stream_obj, 'params') else {}
-    json_body = {}
-    # Default to GET if probe_http_method is not defined in the stream object
-    probe_http_method = getattr(stream_obj, 'probe_http_method', 'GET').upper()
-
-    has_parent = stream_obj.parent is not None
-    if has_parent:
-        # If the stream has a parent stream, then it's access depends on the parent stream's access.
-        parent_stream_name = stream_obj.parent.tap_stream_id
-        LOGGER.info("Stream {} has parent stream {}. Access depends on parent stream.".format(stream_name, parent_stream_name))
-        return True
-
-    if probe_http_method == "POST":  # Update the json with the probe_search_query
-        json_body = getattr(stream_obj, 'probe_search_query', {})
-
-    try:
-        LOGGER.info("Checking access for stream: {}".format(stream_name))
-        client.probe_stream(path, http_method=probe_http_method, params=params, json=json_body)
-        LOGGER.info("Stream {} is accessible".format(stream_name))
-        return True
-
-    except IntercomScrollExistsError:
-        # A scroll_exists error means a prior scroll session is still open for this workspace.
-        # The endpoint itself is reachable and the stream is accessible — treat as success.
-        LOGGER.info("Stream {} is accessible (scroll already exists for workspace).".format(stream_name))
-        return True
-
-    except (IntercomForbiddenError, IntercomUnauthorizedError) as e:
-        LOGGER.error("Stream {} is not accessible. Error: {}".format(stream_name, str(e)))
-        return False
-
-
-def get_schemas(client: IntercomClient):
+def get_schemas():
     """
     Loads the schemas defined for the tap.
 
@@ -81,24 +26,8 @@ def get_schemas(client: IntercomClient):
     schemas = {}
     field_metadata = {}
 
-    inaccessible_streams = []
-
     for stream_name, stream_object in STREAMS.items():
-        replication_ind = stream_object.to_replicate
-        if replication_ind:
-            # Check if the stream is a child streams and it's parent stream is inaccessible,
-            # then mark the stream as inaccessible without checking access for the child stream.
-            if stream_object.parent and stream_object.parent.tap_stream_id in inaccessible_streams:
-                inaccessible_streams.append(stream_name)
-                LOGGER.warning("Stream {} is a child stream and its parent stream {} is inaccessible,"
-                               " hence marking stream as inaccessible".format(stream_name, stream_object.parent.tap_stream_id))
-                continue
-
-            # Check stream access
-            if not check_stream_access(client, stream_object):
-                inaccessible_streams.append(stream_name)
-                continue
-
+        if stream_object.to_replicate:
             schema_path = get_abs_path('schemas/{}.json'.format(stream_name))
             with open(schema_path) as file:
                 schema = json.load(file)
@@ -121,9 +50,13 @@ def get_schemas(client: IntercomClient):
             # Streams like AdminList have to_replicate=False and are internal helpers with no schema,
             # so they should not be surfaced as a parent-tap-stream-id in catalog metadata.
             parent_class = getattr(stream_object, 'parent', None)
-            if parent_class and hasattr(parent_class, 'tap_stream_id') and getattr(parent_class, 'to_replicate', True):
+            if (parent_class
+                    and hasattr(parent_class, 'tap_stream_id')
+                    and getattr(parent_class, 'to_replicate', True)):
                 parent_tap_stream_id = parent_class.tap_stream_id
-                mdata = metadata.write(mdata, (), 'parent-tap-stream-id', parent_tap_stream_id)
+                mdata = metadata.write(
+                    mdata, (), 'parent-tap-stream-id', parent_tap_stream_id
+                )
 
             if stream_object.replication_key:
                 mdata = metadata.write(
@@ -135,16 +68,5 @@ def get_schemas(client: IntercomClient):
             mdata = metadata.to_list(mdata)
 
             field_metadata[stream_name] = mdata
-
-    # check if any child stream whose parent is not accessible is still in schemas
-    prune_inaccessible_children(schemas, field_metadata, inaccessible_streams)
-
-    if not schemas:  # Raise error if none of the streams were added in schemas.
-        error_msg = "No accessible streams found with the provided credentials. Please check the configuration."
-        LOGGER.error(error_msg)
-        raise IntercomForbiddenError(error_msg)
-
-    if inaccessible_streams:
-        LOGGER.warning("The following streams were found to be inaccessible and have been excluded: {}".format(", ".join(inaccessible_streams)))
 
     return schemas, field_metadata

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -30,7 +30,7 @@ def prune_inaccessible_children(schemas, field_metadata, inaccessible_streams):
 def check_stream_access(client: IntercomClient, stream_obj):
     """
     Checks if the stream is accessible with the provided credentials by making a test API call to the endpoint.
-    If the stream is not accessible, then raises an exception which will be caught in the main function and logged.
+    Returns True if the stream is accessible, False if not (catches IntercomError internally and logs it).
     """
     stream_name = stream_obj.tap_stream_id
 
@@ -49,7 +49,7 @@ def check_stream_access(client: IntercomClient, stream_obj):
         return True
 
     if probe_http_method == "POST":  # Update the json with the probe_search_query
-        json_body = stream_obj.probe_search_query
+        json_body = getattr(stream_obj, 'probe_search_query', {})
 
     try:
         LOGGER.info("Checking access for stream: {}".format(stream_name))

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -3,7 +3,9 @@ import os
 
 from singer import get_logger, metadata
 
-from tap_intercom.client import IntercomClient, IntercomError, IntercomScrollExistsError
+from tap_intercom.client import (IntercomClient, IntercomForbiddenError,
+                                 IntercomScrollExistsError,
+                                 IntercomUnauthorizedError)
 from tap_intercom.streams import STREAMS
 
 LOGGER = get_logger()
@@ -56,12 +58,14 @@ def check_stream_access(client: IntercomClient, stream_obj):
         client.probe_stream(path, http_method=probe_http_method, params=params, json=json_body)
         LOGGER.info("Stream {} is accessible".format(stream_name))
         return True
+
     except IntercomScrollExistsError:
         # A scroll_exists error means a prior scroll session is still open for this workspace.
         # The endpoint itself is reachable and the stream is accessible — treat as success.
         LOGGER.info("Stream {} is accessible (scroll already exists for workspace).".format(stream_name))
         return True
-    except IntercomError as e:
+
+    except (IntercomForbiddenError, IntercomUnauthorizedError) as e:
         LOGGER.error("Stream {} is not accessible. Error: {}".format(stream_name, str(e)))
         return False
 
@@ -130,7 +134,7 @@ def get_schemas(client: IntercomClient):
     if not schemas:  # Raise error if none of the streams were added in schemas.
         error_msg = "No accessible streams found with the provided credentials. Please check the configuration."
         LOGGER.error(error_msg)
-        raise IntercomError(error_msg)
+        raise IntercomForbiddenError(error_msg)
 
     if inaccessible_streams:
         LOGGER.warning("The following streams were found to be inaccessible and have been excluded: {}".format(", ".join(inaccessible_streams)))

--- a/tap_intercom/schema.py
+++ b/tap_intercom/schema.py
@@ -3,7 +3,7 @@ import os
 
 from singer import get_logger, metadata
 
-from tap_intercom.client import IntercomClient, IntercomError
+from tap_intercom.client import IntercomClient, IntercomError, IntercomScrollExistsError
 from tap_intercom.streams import STREAMS
 
 LOGGER = get_logger()
@@ -55,6 +55,11 @@ def check_stream_access(client: IntercomClient, stream_obj):
         LOGGER.info("Checking access for stream: {}".format(stream_name))
         client.probe_stream(path, http_method=probe_http_method, params=params, json=json_body)
         LOGGER.info("Stream {} is accessible".format(stream_name))
+        return True
+    except IntercomScrollExistsError:
+        # A scroll_exists error means a prior scroll session is still open for this workspace.
+        # The endpoint itself is reachable and the stream is accessible — treat as success.
+        LOGGER.info("Stream {} is accessible (scroll already exists for workspace).".format(stream_name))
         return True
     except IntercomError as e:
         LOGGER.error("Stream {} is not accessible. Error: {}".format(stream_name, str(e)))

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -548,6 +548,18 @@ class Conversations(IncrementalStream):
     per_page = MAX_PAGE_SIZE
     child = 'conversation_parts'
 
+    probe_http_method = "POST"
+    probe_search_query = {
+        "pagination": {
+            "per_page": 1
+        },
+        "query": {
+            "field": "id",
+            "operator": "!=",
+            "value": None
+        }
+    }
+
     def set_last_processed(self, state):
         self.last_processed = singer.get_bookmark(
             state, self.tap_stream_id, "last_processed")
@@ -724,6 +736,18 @@ class Contacts(IncrementalStream):
     # addressable_list_fields = ['tags', 'notes', 'companies']
     addressable_list_fields = ['tags', 'companies']
     to_write_intermediate_bookmark = True
+
+    probe_http_method = "POST"
+    probe_search_query = {
+        "pagination": {
+            "per_page": 1
+        },
+        "query": {
+            "field": "id",
+            "operator": "!=",
+            "value": None
+        }
+    }
 
     def get_addressable_list(self, contact_list: dict, stream_metadata: dict) -> dict:
         params = {

--- a/tap_intercom/streams.py
+++ b/tap_intercom/streams.py
@@ -12,7 +12,9 @@ import singer
 from singer import Transformer, metrics, metadata, UNIX_MILLISECONDS_INTEGER_DATETIME_PARSING
 from singer.transform import transform, unix_milliseconds_to_datetime
 
-from tap_intercom.client import (IntercomClient, IntercomError, IntercomNotFoundError)
+from tap_intercom.client import (IntercomClient, IntercomError, IntercomNotFoundError,
+                                 IntercomForbiddenError, IntercomUnauthorizedError,
+                                 IntercomScrollExistsError)
 from tap_intercom.transform import (transform_json, transform_times, find_datetimes_in_schema)
 
 LOGGER = singer.get_logger()
@@ -38,10 +40,92 @@ class BaseStream:
     data_key = None
     child = None
 
-    def __init__(self, client: IntercomClient, catalog, selected_streams):
+    def __init__(self, client: IntercomClient = None,
+                 catalog=None, selected_streams=None):
         self.client = client
         self.catalog = catalog
         self.selected_streams = selected_streams
+
+    def get_probe_data(self, obj, parent_record_id=None):
+        """
+            Prepares and returns data/params required to probe a stream
+        """
+        if parent_record_id is not None:
+            path = obj.path.format(parent_record_id)
+        else:
+            path = obj.path
+
+        params = getattr(obj, 'params', {})
+        json_body = {}
+
+        probe_http_method = getattr(obj, 'probe_http_method', 'GET').upper()
+        if probe_http_method == 'POST':
+            json_body = getattr(obj, 'probe_search_query', {})
+
+        return path, params, probe_http_method, json_body
+
+    def check_access(self) -> bool:
+        """
+        Verify that the API credentials have read access to this stream.
+
+        Returns True if the stream is accessible.
+        Returns False only on HTTP 401 (Unauthorized) or 403 (Forbidden).
+        A scroll_exists (400) response is treated as accessible because it
+        proves a prior successful scroll session was open for this workspace.
+        All other errors propagate so that backoff/retry can handle them.
+        """
+        parent_record_id = None
+
+        if self.parent is not None:
+            # Get a record from parent
+            parent_obj = self.parent
+            path, params, probe_http_method, json_body = self.get_probe_data(parent_obj)
+
+            try:
+                record = self.client.probe_stream(
+                    path,
+                    http_method=probe_http_method,
+                    params=params,
+                    json=json_body,
+                )
+                if hasattr(parent_obj, 'data_key') and parent_obj.data_key is not None:
+                    record = record.get(parent_obj.data_key)[0]
+
+                parent_record_id = record.get('id')
+            except (IntercomForbiddenError, IntercomUnauthorizedError) as exc:
+                LOGGER.warning(
+                    "Parent Stream %s is not accessible. Error: %s",
+                    parent_obj.tap_stream_id, str(exc)
+                )
+                return False
+
+        path, params, probe_http_method, json_body = self.get_probe_data(self, parent_record_id=parent_record_id)
+
+        try:
+            LOGGER.info("Checking access for stream: %s", self.tap_stream_id)
+            self.client.probe_stream(
+                path,
+                http_method=probe_http_method,
+                params=params,
+                json=json_body,
+            )
+            LOGGER.info("Stream %s is accessible", self.tap_stream_id)
+            return True
+        except IntercomScrollExistsError:
+            # scroll_exists means a prior scroll session is still open.
+            # The endpoint is reachable — treat as accessible.
+            LOGGER.info(
+                "Stream %s is accessible "
+                "(scroll already exists for workspace).",
+                self.tap_stream_id
+            )
+            return True
+        except (IntercomForbiddenError, IntercomUnauthorizedError) as exc:
+            LOGGER.warning(
+                "Stream %s is not accessible. Error: %s",
+                self.tap_stream_id, str(exc)
+            )
+            return False
 
     def get_records(self, bookmark_datetime: datetime = None, is_parent: bool = False, stream_metadata=None) -> list:
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -33,6 +33,7 @@ class IntercomBaseTest(unittest.TestCase):
     API_LIMIT = "max-row-limit"
     INCREMENTAL = "INCREMENTAL"
     FULL_TABLE = "FULL_TABLE"
+    IS_FORBIDDEN_STREAM = "is-forbidden-stream"
     START_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
     RECORD_REPLICATION_KEY_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
     BOOKMARK_COMPARISON_FORMAT = "%Y-%m-%dT00:00:00+00:00"
@@ -112,7 +113,8 @@ class IntercomBaseTest(unittest.TestCase):
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"updated_at"},
                 self.EXPECTED_PARENT_STREAM: "conversations",
-                self.OBEYS_START_DATE : True
+                self.OBEYS_START_DATE : True,
+                self.IS_FORBIDDEN_STREAM: True
             },
             "contact_attributes": {
                 self.PRIMARY_KEYS: {"_sdc_record_hash"},
@@ -143,10 +145,13 @@ class IntercomBaseTest(unittest.TestCase):
             }
         }
 
-
     def expected_streams(self):
         """A set of expected stream names"""
-        return set(self.expected_metadata().keys())
+        return {
+            stream_name
+            for stream_name, metadata in self.expected_metadata().items()
+            if not metadata.get(self.IS_FORBIDDEN_STREAM, False)
+        }
 
     def child_streams(self):
         """

--- a/tests/test_intercom_pagination.py
+++ b/tests/test_intercom_pagination.py
@@ -7,7 +7,7 @@ from tap_tester import runner, connections
 
 from base import IntercomBaseTest
 
-class RechargePaginationTest(IntercomBaseTest):
+class IntercomPaginationTest(IntercomBaseTest):
     
     @staticmethod
     def name():

--- a/tests/unittests/test_client.py
+++ b/tests/unittests/test_client.py
@@ -82,3 +82,38 @@ class TestMethods(unittest.TestCase):
 
         self.intercom_client.perform('POST','path')
         self.assertEqual(mocked_post_request.call_count,1)
+
+
+class TestProbeStreamAndMethods(unittest.TestCase):
+
+    intercom_client = IntercomClient(config_request_timeout="", access_token="test_token")
+
+    @mock.patch("tap_intercom.client.IntercomClient.get")
+    @mock.patch("tap_intercom.client.IntercomClient.post")
+    def test_probe_stream_calls_get_by_default(self, mock_post, mock_get):
+        self.intercom_client.probe_stream('path')
+        mock_get.assert_called_once()
+        mock_post.assert_not_called()
+
+    @mock.patch("tap_intercom.client.IntercomClient.get")
+    @mock.patch("tap_intercom.client.IntercomClient.post")
+    def test_probe_stream_calls_post_for_post_method(self, mock_post, mock_get):
+        self.intercom_client.probe_stream('path', http_method='POST')
+        mock_post.assert_called_once()
+        mock_get.assert_not_called()
+
+    @mock.patch("requests.Session.request")
+    def test_get_method_delegates_to_request(self, mock_request):
+        mock_request.return_value = get_mock_http_response(200, json.dumps({'type': ''}))
+        client = IntercomClient(config_request_timeout="", access_token="test_token")
+        client._IntercomClient__verified = True
+        client.get('test_path')
+        self.assertEqual(mock_request.call_args[0][0], 'GET')
+
+    @mock.patch("requests.Session.request")
+    def test_post_method_delegates_to_request(self, mock_request):
+        mock_request.return_value = get_mock_http_response(200, json.dumps({'type': ''}))
+        client = IntercomClient(config_request_timeout="", access_token="test_token")
+        client._IntercomClient__verified = True
+        client.post('test_path', json={})
+        self.assertEqual(mock_request.call_args[0][0], 'POST')

--- a/tests/unittests/test_discovery.py
+++ b/tests/unittests/test_discovery.py
@@ -1,0 +1,549 @@
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from singer.catalog import Catalog
+
+from tap_intercom.client import (
+    IntercomClient,
+    IntercomForbiddenError,
+    IntercomUnauthorizedError,
+    IntercomScrollExistsError,
+)
+from tap_intercom.discover import (
+    _apply_access_checks,
+    _prune_inaccessible_children,
+    discover,
+)
+from tap_intercom.streams import (
+    BaseStream,
+    Companies,
+    Contacts,
+    Conversations,
+    ConversationParts,
+    Tags,
+    Teams,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _make_mock_stream_cls(tap_stream_id, parent=None, accessible=True):
+    """
+    Return a mock stream *class* whose instances report a fixed check_access().
+
+    parent   -- set to a mock/class to simulate a child stream
+    accessible -- return value of check_access()
+    """
+    cls = mock.MagicMock()
+    cls.parent = parent
+    instance = mock.MagicMock()
+    instance.tap_stream_id = tap_stream_id
+    instance.check_access.return_value = accessible
+    cls.return_value = instance
+    return cls
+
+
+def _make_schemas(stream_names):
+    """Build minimal schemas / field_metadata dicts for the given names."""
+    schemas = {name: {'type': 'object'} for name in stream_names}
+    field_metadata = {name: [] for name in stream_names}
+    return schemas, field_metadata
+
+
+# ---------------------------------------------------------------------------
+# 1.  BaseStream.check_access()
+# ---------------------------------------------------------------------------
+
+class TestBaseStreamCheckAccess(unittest.TestCase):
+    """Tests for the check_access() method added to BaseStream."""
+
+    def setUp(self):
+        self.client = IntercomClient(
+            access_token='test_token', config_request_timeout=''
+        )
+
+    # --- child streams probe parent then themselves ------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_probes_parent_then_self(self, mock_probe):
+        """Child stream probes parent first (to get an id) then probes itself."""
+        parent_id = 'conv-abc'
+        mock_probe.side_effect = [
+            {Conversations.data_key: [{'id': parent_id}]},  # parent probe
+            {},                                              # child probe
+        ]
+        stream = ConversationParts(client=self.client)
+        result = stream.check_access()
+
+        self.assertTrue(result)
+        self.assertEqual(mock_probe.call_count, 2)
+        # First call uses parent (Conversations) path and POST method
+        first_args = mock_probe.call_args_list[0]
+        self.assertEqual(first_args[0][0], Conversations.path)
+        self.assertEqual(first_args[1]['http_method'], 'POST')
+        # Second call uses child path formatted with parent id
+        second_args = mock_probe.call_args_list[1]
+        self.assertIn(parent_id, second_args[0][0])
+        self.assertEqual(second_args[1]['http_method'], 'GET')
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_returns_false_when_parent_forbidden(self, mock_probe):
+        """403 on parent probe → False without probing child."""
+        mock_probe.side_effect = IntercomForbiddenError('HTTP-error-code: 403')
+        stream = ConversationParts(client=self.client)
+
+        result = stream.check_access()
+
+        self.assertFalse(result)
+        mock_probe.assert_called_once()  # only parent probe was attempted
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_returns_false_when_parent_unauthorized(self, mock_probe):
+        """401 on parent probe → False without probing child."""
+        mock_probe.side_effect = IntercomUnauthorizedError('HTTP-error-code: 401')
+        stream = ConversationParts(client=self.client)
+
+        result = stream.check_access()
+
+        self.assertFalse(result)
+        mock_probe.assert_called_once()
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_returns_false_when_self_probe_forbidden(self, mock_probe):
+        """Parent probe succeeds; 403 on child probe → False."""
+        parent_id = 'conv-xyz'
+        mock_probe.side_effect = [
+            {Conversations.data_key: [{'id': parent_id}]},
+            IntercomForbiddenError('HTTP-error-code: 403'),
+        ]
+        stream = ConversationParts(client=self.client)
+
+        result = stream.check_access()
+
+        self.assertFalse(result)
+        self.assertEqual(mock_probe.call_count, 2)
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_parent_without_data_key_uses_record_directly(self, mock_probe):
+        """When parent has no data_key, the raw probe response is used for id."""
+        parent_id = 'raw-id-99'
+        mock_probe.side_effect = [
+            {'id': parent_id},  # raw response (no data_key wrapper)
+            {},
+        ]
+        # Temporarily remove data_key from parent class
+        original_data_key = Conversations.data_key
+        Conversations.data_key = None
+        try:
+            stream = ConversationParts(client=self.client)
+            result = stream.check_access()
+        finally:
+            Conversations.data_key = original_data_key
+
+        self.assertTrue(result)
+        second_args = mock_probe.call_args_list[1]
+        self.assertIn(parent_id, second_args[0][0])
+
+    # --- GET stream uses correct probe kwargs ------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_get_stream_probe_called_with_get_method(self, mock_probe):
+        """GET stream: probe_stream is called with http_method='GET'."""
+        mock_probe.return_value = {'type': 'list'}
+        stream = Tags(client=self.client)
+
+        result = stream.check_access()
+
+        self.assertTrue(result)
+        mock_probe.assert_called_once_with(
+            stream.path,
+            http_method='GET',
+            params=stream.params,
+            json={},
+        )
+
+    # --- POST stream uses correct probe kwargs -----------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_post_stream_probe_called_with_post_method(self, mock_probe):
+        """POST stream: probe_stream called with http_method='POST' and body."""
+        mock_probe.return_value = {'conversations': []}
+        stream = Conversations(client=self.client)
+
+        result = stream.check_access()
+
+        self.assertTrue(result)
+        mock_probe.assert_called_once_with(
+            stream.path,
+            http_method='POST',
+            params=stream.params,
+            json=stream.probe_search_query,
+        )
+
+    # --- accessible stream returns True ------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_accessible_stream_returns_true(self, mock_probe):
+        """Successful probe returns True."""
+        mock_probe.return_value = {'type': 'list'}
+        self.assertTrue(Tags(client=self.client).check_access())
+
+    # --- parameterized: auth errors return False ---------------------------
+
+    @parameterized.expand([
+        ['401_unauthorized',
+         IntercomUnauthorizedError, 'HTTP-error-code: 401', Tags],
+        ['403_forbidden',
+         IntercomForbiddenError, 'HTTP-error-code: 403', Companies],
+    ])
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_auth_error_returns_false(
+        self, _name, exc_class, exc_msg, stream_cls, mock_probe
+    ):
+        """HTTP 401 / 403 -> returns False (never re-raised)."""
+        mock_probe.side_effect = exc_class(exc_msg)
+        result = stream_cls(client=self.client).check_access()
+        self.assertFalse(result)
+
+    # --- scroll_exists treated as accessible -------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_scroll_exists_returns_true(self, mock_probe):
+        """
+        scroll_exists (400) proves a prior scroll session was open and the
+        endpoint is reachable — must return True.
+        """
+        mock_probe.side_effect = IntercomScrollExistsError(
+            'HTTP-error-code: 400, Error_Code:scroll_exists'
+        )
+        result = Companies(client=self.client).check_access()
+        self.assertTrue(result)
+
+    # --- parameterized: correct log level on access check ------------------
+
+    @parameterized.expand([
+        ['unauthorized_logs_warning',
+         IntercomUnauthorizedError('HTTP-error-code: 401'), 'warning', True],
+        ['forbidden_logs_warning',
+         IntercomForbiddenError('HTTP-error-code: 403'), 'warning', True],
+        ['accessible_no_error_log', None, 'error', False],
+    ])
+    @mock.patch('tap_intercom.streams.LOGGER')
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_log_level(
+        self, _name, exc, log_method, expect_called, mock_probe, mock_logger
+    ):
+        """Verify the correct log level is (or is not) triggered."""
+        if exc:
+            mock_probe.side_effect = exc
+        else:
+            mock_probe.return_value = {}
+
+        Tags(client=self.client).check_access()
+
+        logger_fn = getattr(mock_logger, log_method)
+        if expect_called:
+            logger_fn.assert_called()
+        else:
+            logger_fn.assert_not_called()
+
+    @mock.patch('tap_intercom.streams.LOGGER')
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_scroll_exists_logs_info_not_warning(self, mock_probe, mock_logger):
+        """scroll_exists must log at INFO level only — no WARNING or ERROR."""
+        mock_probe.side_effect = IntercomScrollExistsError(
+            'HTTP-error-code: 400, Error_Code:scroll_exists'
+        )
+        Companies(client=self.client).check_access()
+
+        mock_logger.warning.assert_not_called()
+        mock_logger.error.assert_not_called()
+        mock_logger.info.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# 2.  _prune_inaccessible_children()
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Tests for _prune_inaccessible_children() in discover.py."""
+
+    def test_child_removed_when_parent_absent_from_schemas(self):
+        """
+        conversation_parts must be pruned when conversations is absent from
+        schemas (removed because it was inaccessible).
+        """
+        schemas = {'conversation_parts': {}, 'tags': {}}
+        field_metadata = {'conversation_parts': [], 'tags': []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn('conversation_parts', schemas)
+        self.assertNotIn('conversation_parts', field_metadata)
+
+    def test_child_not_pruned_when_parent_present(self):
+        """Child stream is retained when its parent is still in schemas."""
+        schemas = {'conversations': {}, 'conversation_parts': {}}
+        field_metadata = {'conversations': [], 'conversation_parts': []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn('conversation_parts', schemas)
+        self.assertIn('conversation_parts', field_metadata)
+
+    def test_unrelated_streams_unaffected(self):
+        """Streams without a replicable parent in schemas are untouched."""
+        schemas = {'conversations': {}, 'conversation_parts': {}, 'tags': {}}
+        field_metadata = {
+            'conversations': [], 'conversation_parts': [], 'tags': []
+        }
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn('tags', schemas)
+        self.assertIn('conversations', schemas)
+
+    def test_child_with_non_replicable_parent_not_pruned(self):
+        """
+        'admins' has parent AdminList (to_replicate=False).  Since AdminList is
+        never in schemas (not replicable), admins must NOT be pruned.
+        """
+        schemas = {'admins': {}, 'tags': {}}
+        field_metadata = {'admins': [], 'tags': []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertIn('admins', schemas)
+
+    def test_noop_when_child_already_absent(self):
+        """Must not raise if the child stream was never added to schemas."""
+        schemas = {'tags': {}}
+        field_metadata = {'tags': []}
+
+        try:
+            _prune_inaccessible_children(schemas, field_metadata)
+        except Exception as exc:  # pragma: no cover
+            self.fail(
+                '_prune_inaccessible_children raised unexpectedly: {}'.format(
+                    exc
+                )
+            )
+
+    @mock.patch('tap_intercom.discover.LOGGER')
+    def test_warning_logged_for_pruned_child(self, mock_logger):
+        """A WARNING must be emitted when a child stream is pruned."""
+        schemas = {'conversation_parts': {}, 'tags': {}}
+        field_metadata = {'conversation_parts': [], 'tags': []}
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        mock_logger.warning.assert_called()
+        self.assertIn('conversation_parts', str(mock_logger.warning.call_args))
+
+    @parameterized.expand([
+        ['conversations_inaccessible', 'conversations', 'conversation_parts'],
+    ])
+    def test_parameterized_prune(
+        self, _name, inaccessible_parent, expected_pruned_child
+    ):
+        """Parameterized: child is pruned when its replicable parent is gone."""
+        schemas = {inaccessible_parent: {}, expected_pruned_child: {}, 'tags': {}}
+        field_metadata = {
+            inaccessible_parent: [], expected_pruned_child: [], 'tags': []
+        }
+        # Remove the parent to simulate it being denied
+        schemas.pop(inaccessible_parent)
+        field_metadata.pop(inaccessible_parent)
+
+        _prune_inaccessible_children(schemas, field_metadata)
+
+        self.assertNotIn(expected_pruned_child, schemas)
+        self.assertNotIn(expected_pruned_child, field_metadata)
+
+
+# ---------------------------------------------------------------------------
+# 3.  _apply_access_checks()
+# ---------------------------------------------------------------------------
+
+class TestApplyAccessChecks(unittest.TestCase):
+    """Tests for _apply_access_checks() in discover.py."""
+
+    def setUp(self):
+        self.client = IntercomClient(
+            access_token='test_token', config_request_timeout=''
+        )
+
+    # --- all accessible — schemas unchanged --------------------------------
+
+    def test_all_accessible_schemas_unchanged(self):
+        """When every stream is accessible, schemas is not modified."""
+        mock_streams = {
+            'tags': _make_mock_stream_cls('tags', accessible=True),
+            'teams': _make_mock_stream_cls('teams', accessible=True),
+        }
+        schemas, field_metadata = _make_schemas(['tags', 'teams'])
+
+        with mock.patch('tap_intercom.discover.STREAMS', mock_streams):
+            _apply_access_checks(self.client, schemas, field_metadata)
+
+        self.assertIn('tags', schemas)
+        self.assertIn('teams', schemas)
+
+    # --- parameterized: single denied stream excluded; others survive ------
+
+    @parameterized.expand([
+        ['tags_denied',  'tags',  ['teams']],
+        ['teams_denied', 'teams', ['tags']],
+    ])
+    def test_unauthorized_stream_excluded(
+        self, _name, denied, expected_present
+    ):
+        """A denied stream must not appear in schemas after access checks."""
+        mock_streams = {
+            denied: _make_mock_stream_cls(denied, accessible=False),
+            **{
+                name: _make_mock_stream_cls(name, accessible=True)
+                for name in expected_present
+            },
+        }
+        schemas, field_metadata = _make_schemas([denied] + expected_present)
+
+        with mock.patch('tap_intercom.discover.STREAMS', mock_streams):
+            _apply_access_checks(self.client, schemas, field_metadata)
+
+        self.assertNotIn(denied, schemas)
+        for name in expected_present:
+            self.assertIn(name, schemas)
+
+    # --- all denied → IntercomForbiddenError --------------------------------
+
+    def test_all_unauthorized_raises_forbidden_error(self):
+        """All streams inaccessible -> IntercomForbiddenError raised."""
+        mock_streams = {
+            'tags': _make_mock_stream_cls('tags', accessible=False),
+            'teams': _make_mock_stream_cls('teams', accessible=False),
+        }
+        schemas, field_metadata = _make_schemas(['tags', 'teams'])
+
+        with mock.patch('tap_intercom.discover.STREAMS', mock_streams):
+            with self.assertRaises(IntercomForbiddenError):
+                _apply_access_checks(self.client, schemas, field_metadata)
+
+    # --- child pruned when its parent is denied (cascade) ------------------
+
+    def test_child_excluded_when_parent_denied(self):
+        """
+        When conversations is denied, conversation_parts must also be removed
+        via _prune_inaccessible_children.
+        """
+        parent_cls = mock.MagicMock()
+        parent_cls.tap_stream_id = 'conversations'
+
+        mock_streams = {
+            'conversations': _make_mock_stream_cls(
+                'conversations', accessible=False
+            ),
+            'conversation_parts': _make_mock_stream_cls(
+                'conversation_parts', parent=parent_cls, accessible=True
+            ),
+            'tags': _make_mock_stream_cls('tags', accessible=True),
+        }
+        schemas, field_metadata = _make_schemas(
+            ['conversations', 'conversation_parts', 'tags']
+        )
+
+        with mock.patch('tap_intercom.discover.STREAMS', mock_streams):
+            _apply_access_checks(self.client, schemas, field_metadata)
+
+        self.assertNotIn('conversations', schemas)
+        self.assertNotIn('conversation_parts', schemas)
+        self.assertIn('tags', schemas)
+
+    # --- warning logged for inaccessible streams ---------------------------
+
+    @mock.patch('tap_intercom.discover.LOGGER')
+    def test_warning_logged_for_inaccessible_streams(self, mock_logger):
+        """A WARNING must list the excluded streams."""
+        mock_streams = {
+            'tags': _make_mock_stream_cls('tags', accessible=False),
+            'teams': _make_mock_stream_cls('teams', accessible=True),
+        }
+        schemas, field_metadata = _make_schemas(['tags', 'teams'])
+
+        with mock.patch('tap_intercom.discover.STREAMS', mock_streams):
+            _apply_access_checks(self.client, schemas, field_metadata)
+
+        mock_logger.warning.assert_called()
+        self.assertIn('tags', str(mock_logger.warning.call_args))
+
+
+# ---------------------------------------------------------------------------
+# 4.  discover()
+# ---------------------------------------------------------------------------
+
+class TestDiscover(unittest.TestCase):
+    """End-to-end tests for discover(client)."""
+
+    def setUp(self):
+        self.client = IntercomClient(
+            access_token='test_token', config_request_timeout=''
+        )
+
+    @mock.patch('tap_intercom.discover._apply_access_checks')
+    def test_discover_returns_catalog_instance(self, _mock_access):
+        """discover() must return a singer Catalog object."""
+        self.assertIsInstance(discover(self.client), Catalog)
+
+    @mock.patch('tap_intercom.discover._apply_access_checks')
+    def test_discover_catalog_has_streams(self, _mock_access):
+        """Catalog returned by discover() must contain at least one stream."""
+        catalog = discover(self.client)
+        self.assertGreater(len(catalog.streams), 0)
+
+    @mock.patch('tap_intercom.discover._apply_access_checks')
+    def test_discover_catalog_stream_ids_match_replicable_streams(
+        self, _mock_access
+    ):
+        """
+        When _apply_access_checks is a no-op, all replicable streams appear
+        in the catalog.
+        """
+        from tap_intercom.streams import STREAMS
+
+        catalog = discover(self.client)
+        catalog_ids = {s.tap_stream_id for s in catalog.streams}
+        expected = {
+            name for name, cls in STREAMS.items() if cls.to_replicate
+        }
+        self.assertEqual(catalog_ids, expected)
+
+    def test_discover_invokes_apply_access_checks(self):
+        """discover() must delegate access gating to _apply_access_checks."""
+        with mock.patch(
+            'tap_intercom.discover._apply_access_checks'
+        ) as mock_access:
+            discover(self.client)
+
+        mock_access.assert_called_once()
+        # First positional arg is the client
+        self.assertEqual(mock_access.call_args[0][0], self.client)
+
+    @mock.patch('tap_intercom.streams.BaseStream.check_access',
+                return_value=True)
+    def test_discover_full_integration_all_accessible(self, _mock_check):
+        """
+        Full integration path: with all streams accessible, all replicable
+        streams appear in the catalog.
+        """
+        from tap_intercom.streams import STREAMS
+
+        catalog = discover(self.client)
+        catalog_ids = {s.tap_stream_id for s in catalog.streams}
+        expected = {
+            name for name, cls in STREAMS.items() if cls.to_replicate
+        }
+        self.assertEqual(catalog_ids, expected)

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -34,8 +34,7 @@ class TestIntercomInit(unittest.TestCase):
 
         # Return mocked args
         mock_args.return_value = Parse_Args(discover=test_data[0], catalog=test_data[1])
-        with mock_client:
-            main()
+        main()
 
         self.assertEqual(mock_discover.called,exp[0])
         self.assertEqual(mock_sync.called,exp[1])
@@ -43,5 +42,5 @@ class TestIntercomInit(unittest.TestCase):
     def test_discover_coverage(self, mock_client):
         """Test discover returns catalog having an instance of singer Catalog"""
 
-        catalog = discover(mock_client)
+        catalog = discover(mock_client.return_value)
         self.assertIsInstance(catalog, Catalog)

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 from tap_intercom import main
 from parameterized import parameterized
-from tap_intercom import discover
+from tap_intercom.discover import discover
 from singer.catalog import Catalog
 
 
@@ -27,7 +27,7 @@ class TestIntercomInit(unittest.TestCase):
         ["discover_and_sync_called", [False, False], [True, True]]
     ])
     @mock.patch('singer.utils.parse_args')
-    @mock.patch('tap_intercom.discover')
+    @mock.patch('tap_intercom._discover')
     @mock.patch('tap_intercom.sync')
     def test_init(self, test_name, test_data, exp, mock_sync, mock_discover, mock_args, mock_client):
         """Test init file for different flag scenarios"""

--- a/tests/unittests/test_init.py
+++ b/tests/unittests/test_init.py
@@ -9,34 +9,39 @@ from singer.catalog import Catalog
 class Parse_Args:
     """Mocked Parse args class"""
 
-    def __init__(self,discover=False,config = None,state = None, catalog = None) -> None:
+    def __init__(self,discover=False, state = None, catalog = None) -> None:
         self.discover = discover
-        self.config = config
         self.state = state
         self.catalog = catalog
+        self.config = {
+            "access_token": "test_token",
+            "user_agent": "test_agent"
+        }
 
+
+@mock.patch('tap_intercom.client.IntercomClient.__enter__', return_value=mock.MagicMock())
 class TestIntercomInit(unittest.TestCase):
     @parameterized.expand([ # test_name, [discover_flag, catalog_flag], [discover_called, sync_called]
-        ["discover_called", [True,False], [True, False]],
-        ["sync_called", [False,True], [False, True]],
-        ["discover_and_sync_called", [False,False], [True, True]]
+        ["discover_called", [True, False], [True, False]],
+        ["sync_called", [False, True], [False, True]],
+        ["discover_and_sync_called", [False, False], [True, True]]
     ])
     @mock.patch('singer.utils.parse_args')
     @mock.patch('tap_intercom.discover')
     @mock.patch('tap_intercom.sync')
-    def test_init(self,test_name,test_data,exp,mock_sync,mock_discover,mock_args):
+    def test_init(self, test_name, test_data, exp, mock_sync, mock_discover, mock_args, mock_client):
         """Test init file for different flag scenarios"""
 
         # Return mocked args
-        mock_args.return_value = Parse_Args(discover = test_data[0],catalog = test_data[1])
-        main()
+        mock_args.return_value = Parse_Args(discover=test_data[0], catalog=test_data[1])
+        with mock_client:
+            main()
 
         self.assertEqual(mock_discover.called,exp[0])
         self.assertEqual(mock_sync.called,exp[1])
-    
-    def test_discover_coverage(self):
+
+    def test_discover_coverage(self, mock_client):
         """Test discover returns catalog having an instance of singer Catalog"""
 
-        catalog = discover()
-        self.assertIsInstance(catalog,Catalog)
-        
+        catalog = discover(mock_client)
+        self.assertIsInstance(catalog, Catalog)

--- a/tests/unittests/test_parent_child_sync.py
+++ b/tests/unittests/test_parent_child_sync.py
@@ -96,3 +96,40 @@ class TestParentChildWriteRecords(unittest.TestCase):
         conversations.sync(state={}, stream_schema={}, stream_metadata={}, config=config, transformer=None)
         self.assertEqual(mocked_transform.call_count, 1)
         self.assertEqual(mocked_sync_substream.call_count, 1)
+
+
+class TestSkipRecordsBranch(unittest.TestCase):
+    """Covers skip_records=True path (skipped_parent_ids.append + continue)."""
+
+    @mock.patch('singer.write_schema')
+    @mock.patch('tap_intercom.streams.BaseStream.sync_substream')
+    @mock.patch('tap_intercom.streams.transform', side_effect=transform)
+    @mock.patch('tap_intercom.streams.Conversations.get_records')
+    def test_skip_records_appends_to_skipped_ids(
+        self, mocked_get_records, mocked_transform, mocked_sync_substream, mocked_write_schema
+    ):
+        """When last_processed is set, records with id <= last_processed are skipped."""
+        skipped_id = 'conv-05'
+        last_proc = 'conv-10'
+        mocked_get_records.return_value = [
+            {'id': skipped_id, 'updated_at': 1640636000000},
+        ]
+        client = IntercomClient('test_access_token', 300)
+        state = {
+            'bookmarks': {
+                'conversations': {'last_processed': last_proc},
+                'conversation_parts': {},
+            }
+        }
+        conversations = Conversations(
+            client=client,
+            catalog=Catalog(['conversations', 'conversation_parts']),
+            selected_streams=['conversations', 'conversation_parts'],
+        )
+        conversations.sync(
+            state=state, stream_schema={}, stream_metadata={},
+            config={'start_date': '2021-01-01'}, transformer=None,
+        )
+        self.assertIn(
+            (skipped_id, 1640636000000), conversations.skipped_parent_ids
+        )

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -153,19 +153,13 @@ class TestCheckStreamAccess(unittest.TestCase):
         ['401_unauthorized',
          IntercomUnauthorizedError, 'HTTP-error-code: 401', 'contacts'],
         ['403_forbidden',
-         IntercomForbiddenError, 'HTTP-error-code: 403', 'companies'],
-        ['404_not_found',
-         IntercomNotFoundError, 'HTTP-error-code: 404', 'segments'],
-        ['408_request_timeout',
-         IntercomRequestTimeoutError, 'HTTP-error-code: 408', 'teams'],
-        ['generic_intercom_error',
-         IntercomError, 'some permission error', 'tags'],
+         IntercomForbiddenError, 'HTTP-error-code: 403', 'companies']
     ])
     @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
     def test_error_returns_false(
         self, _name, exc_class, exc_msg, stream_name, mock_probe
     ):
-        """Any IntercomError (or subclass) -> returns False, never re-raised."""
+        """Only IntercomForbiddenError and IntercomUnauthorizedError are handled to raise error"""
         mock_probe.side_effect = exc_class(exc_msg)
         stream_obj = _make_stream_obj(stream_name, stream_name)
 

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -1,500 +1,91 @@
 import unittest
-from unittest import mock
 
-from parameterized import parameterized
+from tap_intercom.schema import get_schemas
+from tap_intercom.streams import STREAMS
 
-from tap_intercom.client import (IntercomClient, IntercomError,
-                                 IntercomForbiddenError, IntercomNotFoundError,
-                                 IntercomRequestTimeoutError,
-                                 IntercomScrollExistsError,
-                                 IntercomUnauthorizedError)
-from tap_intercom.schema import (check_stream_access, get_schemas,
-                                 prune_inaccessible_children)
-
-
-def _make_stream_obj(
-    tap_stream_id,
-    path,
-    parent=None,
-    to_replicate=True,
-    probe_http_method='GET',
-    params=None,
-    probe_search_query=None,
-):
-    """
-    Helper: returns a mock stream object with explicit attributes
-    so that MagicMock auto-creation does not pollute kwargs.
-    """
-    obj = mock.MagicMock()
-    obj.tap_stream_id = tap_stream_id
-    obj.path = path
-    obj.parent = parent
-    obj.to_replicate = to_replicate
-    obj.key_properties = ['id']
-    obj.valid_replication_keys = []
-    obj.replication_method = 'FULL_TABLE'
-    obj.replication_key = None
-    obj.probe_http_method = probe_http_method
-    obj.params = params if params is not None else {}
-    if probe_search_query is not None:
-        obj.probe_search_query = probe_search_query
-    return obj
-
-
-def _make_parent_obj(tap_stream_id):
-    """Returns a minimal mock representing a parent stream class."""
-    parent = mock.MagicMock()
-    parent.tap_stream_id = tap_stream_id
-    return parent
-
-
-# ---------------------------------------------------------------------------
-# Tests for check_stream_access()
-# ---------------------------------------------------------------------------
-
-class TestCheckStreamAccess(unittest.TestCase):
-    """Tests for check_stream_access()"""
-
-    def setUp(self):
-        self.client = IntercomClient(
-            access_token='test_token', config_request_timeout=''
-        )
-
-    # -------------------------------------------------------------------
-    # Child streams return True immediately — probe_stream never called
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_child_stream_returns_true_without_probe(self, mock_probe):
-        """
-        Streams with a parent must return True immediately;
-        probe_stream must never be called for them.
-        """
-        parent = _make_parent_obj('conversations')
-        stream_obj = _make_stream_obj('conversation_parts', 'conversations/{}',
-                                      parent=parent)
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertTrue(result)
-        mock_probe.assert_not_called()
-
-    # -------------------------------------------------------------------
-    # GET stream — probe called with correct kwargs
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_get_stream_probe_called_with_get_method(self, mock_probe):
-        """GET stream: probe_stream called with http_method='GET'."""
-        mock_probe.return_value = {'type': 'list'}
-        stream_obj = _make_stream_obj('tags', 'tags',
-                                      probe_http_method='GET',
-                                      params={'include_count': 'true'})
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertTrue(result)
-        mock_probe.assert_called_once_with(
-            'tags',
-            http_method='GET',
-            params={'include_count': 'true'},
-            json={},
-        )
-
-    # -------------------------------------------------------------------
-    # POST stream — probe called with http_method='POST' and search query
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_post_stream_probe_called_with_post_method_and_query(
-        self, mock_probe
-    ):
-        """POST stream: probe_stream called with http_method='POST' and json body."""
-        mock_probe.return_value = {'conversations': []}
-        probe_query = {
-            'pagination': {'per_page': 1},
-            'query': {'field': 'id', 'operator': '!=', 'value': None},
-        }
-        stream_obj = _make_stream_obj(
-            'conversations', 'conversations/search',
-            probe_http_method='POST',
-            probe_search_query=probe_query,
-        )
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertTrue(result)
-        mock_probe.assert_called_once_with(
-            'conversations/search',
-            http_method='POST',
-            params={},
-            json=probe_query,
-        )
-
-    # -------------------------------------------------------------------
-    # Accessible stream returns True
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_accessible_stream_returns_true(self, mock_probe):
-        """probe_stream succeeds -> returns True."""
-        mock_probe.return_value = {'type': 'list'}
-        stream_obj = _make_stream_obj('tags', 'tags')
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertTrue(result)
-
-    # -------------------------------------------------------------------
-    # Parameterized: various IntercomError subclasses -> returns False
-    # -------------------------------------------------------------------
-
-    @parameterized.expand([
-        ['401_unauthorized',
-         IntercomUnauthorizedError, 'HTTP-error-code: 401', 'contacts'],
-        ['403_forbidden',
-         IntercomForbiddenError, 'HTTP-error-code: 403', 'companies']
-    ])
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_error_returns_false(
-        self, _name, exc_class, exc_msg, stream_name, mock_probe
-    ):
-        """Only IntercomForbiddenError and IntercomUnauthorizedError are handled to raise error"""
-        mock_probe.side_effect = exc_class(exc_msg)
-        stream_obj = _make_stream_obj(stream_name, stream_name)
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertFalse(result)
-
-    # -------------------------------------------------------------------
-    # scroll_exists (400) must return True — endpoint is reachable
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_scroll_exists_error_returns_true(self, mock_probe):
-        """
-        IntercomScrollExistsError means a scroll session is already open,
-        which proves the endpoint is reachable. Must return True, not False.
-        """
-        mock_probe.side_effect = IntercomScrollExistsError(
-            'HTTP-error-code: 400, Error:scroll already exists '
-            'for this workspace, Error_Code:scroll_exists'
-        )
-        stream_obj = _make_stream_obj('companies', 'companies/scroll')
-
-        result = check_stream_access(self.client, stream_obj)
-
-        self.assertTrue(result)
-
-    @mock.patch('tap_intercom.schema.LOGGER')
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_scroll_exists_logs_info_not_error(self, mock_probe, mock_logger):
-        """scroll_exists must log at INFO level, not ERROR."""
-        mock_probe.side_effect = IntercomScrollExistsError(
-            'HTTP-error-code: 400, Error_Code:scroll_exists'
-        )
-        stream_obj = _make_stream_obj('companies', 'companies/scroll')
-
-        check_stream_access(self.client, stream_obj)
-
-        mock_logger.error.assert_not_called()
-        mock_logger.info.assert_called()
-
-    # -------------------------------------------------------------------
-    # Parameterized: correct log level emitted
-    # -------------------------------------------------------------------
-
-    @parameterized.expand([
-        ['unauthorized_logs_error',
-         IntercomUnauthorizedError('HTTP-error-code: 401'), 'error', True],
-        ['forbidden_logs_error',
-         IntercomForbiddenError('HTTP-error-code: 403'), 'error', True],
-        ['accessible_does_not_log_error', None, 'error', False],
-    ])
-    @mock.patch('tap_intercom.schema.LOGGER')
-    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
-    def test_log_behaviour(
-        self, _name, exc, log_method, expect_called, mock_probe, mock_logger
-    ):
-        """Verify the correct log level is (or is not) triggered."""
-        if exc:
-            mock_probe.side_effect = exc
-        else:
-            mock_probe.return_value = {}
-
-        stream_obj = _make_stream_obj('contacts', 'contacts')
-        check_stream_access(self.client, stream_obj)
-
-        logger_fn = getattr(mock_logger, log_method)
-        if expect_called:
-            logger_fn.assert_called_once()
-            self.assertIn('contacts', logger_fn.call_args[0][0])
-        else:
-            logger_fn.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Tests for prune_inaccessible_children()
-# ---------------------------------------------------------------------------
-
-class TestPruneInaccessibleChildren(unittest.TestCase):
-    """Tests for prune_inaccessible_children()"""
-
-    def _schemas_and_meta(self, stream_names):
-        """Build minimal schemas/field_metadata dicts for the given stream names."""
-        schemas = {name: {'type': 'object'} for name in stream_names}
-        field_metadata = {name: [] for name in stream_names}
-        return schemas, field_metadata
-
-    def test_child_removed_from_schemas_when_parent_inaccessible(self):
-        """
-        conversation_parts must be removed from schemas when its parent
-        (conversations) is in inaccessible_streams.
-        """
-        schemas, field_metadata = self._schemas_and_meta(
-            ['conversations', 'conversation_parts', 'tags']
-        )
-        inaccessible = ['conversations']
-
-        prune_inaccessible_children(schemas, field_metadata, inaccessible)
-
-        self.assertNotIn('conversation_parts', schemas)
-        self.assertNotIn('conversation_parts', field_metadata)
-
-    def test_child_removed_from_field_metadata_when_parent_inaccessible(self):
-        """field_metadata entry for the child must also be pruned."""
-        schemas, field_metadata = self._schemas_and_meta(
-            ['conversations', 'conversation_parts']
-        )
-        prune_inaccessible_children(schemas, field_metadata, ['conversations'])
-
-        self.assertNotIn('conversation_parts', field_metadata)
-
-    def test_unrelated_streams_unaffected_by_pruning(self):
-        """Streams whose parent is not inaccessible must remain in schemas."""
-        schemas, field_metadata = self._schemas_and_meta(
-            ['conversations', 'conversation_parts', 'tags', 'teams']
-        )
-        prune_inaccessible_children(schemas, field_metadata, ['conversations'])
-
-        self.assertIn('tags', schemas)
-        self.assertIn('teams', schemas)
-
-    def test_no_pruning_when_no_inaccessible_streams(self):
-        """No streams should be removed when inaccessible_streams is empty."""
-        schemas, field_metadata = self._schemas_and_meta(
-            ['conversations', 'conversation_parts', 'tags']
-        )
-        prune_inaccessible_children(schemas, field_metadata, [])
-
-        self.assertIn('conversation_parts', schemas)
-        self.assertIn('conversation_parts', field_metadata)
-
-    def test_noop_when_child_not_already_in_schemas(self):
-        """
-        prune_inaccessible_children must not raise even if the child stream
-        was never added to schemas (e.g. already skipped during discovery).
-        """
-        schemas, field_metadata = self._schemas_and_meta(['tags'])
-        # conversations is inaccessible but conversation_parts is not in schemas
-        try:
-            prune_inaccessible_children(
-                schemas, field_metadata, ['conversations']
-            )
-        except KeyError:
-            self.fail(
-                'prune_inaccessible_children raised KeyError for a child '
-                'stream that was not in schemas.'
-            )
-
-    @parameterized.expand([
-        ['conversations_inaccessible', 'conversations', 'conversation_parts'],
-    ])
-    def test_parameterized_parent_child_pruning(
-        self, _name, inaccessible_parent, expected_removed_child
-    ):
-        """Parameterized: given inaccessible parent, child is pruned."""
-        schemas, field_metadata = self._schemas_and_meta(
-            [inaccessible_parent, expected_removed_child, 'tags']
-        )
-
-        prune_inaccessible_children(
-            schemas, field_metadata, [inaccessible_parent]
-        )
-
-        self.assertNotIn(expected_removed_child, schemas)
-        self.assertNotIn(expected_removed_child, field_metadata)
-
-
-# ---------------------------------------------------------------------------
-# Tests for get_schemas()
-# ---------------------------------------------------------------------------
 
 class TestGetSchemas(unittest.TestCase):
-    """Tests for get_schemas()"""
+    """
+    Tests for get_schemas() — a pure schema loader with no access logic.
+    """
 
-    def setUp(self):
-        self.client = IntercomClient(
-            access_token='test_token', config_request_timeout=''
-        )
+    def test_all_replicable_streams_included(self):
+        """All streams with to_replicate=True appear in schemas."""
+        schemas, field_metadata = get_schemas()
+        expected = {
+            name for name, cls in STREAMS.items() if cls.to_replicate
+        }
+        self.assertEqual(set(schemas.keys()), expected)
+        self.assertEqual(set(field_metadata.keys()), expected)
 
-    # -------------------------------------------------------------------
-    # All streams authorized
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
-    def test_all_streams_authorized_all_included(self, _mock_access):
-        """All accessible -> all replicable streams appear in the catalog."""
-        schemas, field_metadata = get_schemas(self.client)
-
-        self.assertGreater(len(schemas), 0)
-        self.assertEqual(set(schemas.keys()), set(field_metadata.keys()))
-
-    # -------------------------------------------------------------------
-    # Parameterized: single unauthorized stream excluded; others survive
-    # -------------------------------------------------------------------
-
-    @parameterized.expand([
-        ['tags_denied',     'tags'],
-        ['teams_denied',    'teams'],
-        ['segments_denied', 'segments'],
-    ])
-    @mock.patch('tap_intercom.schema.check_stream_access')
-    def test_unauthorized_stream_excluded_from_catalog(
-        self, _name, denied_stream, mock_access
-    ):
-        """A denied stream must not appear in schemas output."""
-        mock_access.side_effect = (
-            lambda client, obj: obj.tap_stream_id != denied_stream
-        )
-
-        schemas, _ = get_schemas(self.client)
-
-        self.assertNotIn(denied_stream, schemas)
-
-    @parameterized.expand([
-        ['tags_denied',     'tags',     ['teams', 'contacts', 'segments']],
-        ['teams_denied',    'teams',    ['tags',  'contacts', 'segments']],
-        ['segments_denied', 'segments', ['tags',  'teams',    'contacts']],
-    ])
-    @mock.patch('tap_intercom.schema.check_stream_access')
-    def test_authorized_streams_unaffected_when_one_unauthorized(
-        self, _name, denied_stream, expected_present, mock_access
-    ):
-        """Authorized streams must still appear when one stream is denied."""
-        mock_access.side_effect = (
-            lambda client, obj: obj.tap_stream_id != denied_stream
-        )
-
-        schemas, _ = get_schemas(self.client)
-
-        for stream in expected_present:
-            self.assertIn(stream, schemas)
-
-    # -------------------------------------------------------------------
-    # Child stream excluded when parent is inaccessible (early-continue path)
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.schema.LOGGER')
-    @mock.patch('tap_intercom.schema.check_stream_access')
-    def test_child_excluded_when_parent_inaccessible(
-        self, mock_access, mock_logger
-    ):
-        """
-        conversation_parts (child of conversations) must be excluded
-        without calling check_stream_access for it, and a WARNING logged.
-        """
-        mock_access.side_effect = (
-            lambda client, obj: obj.tap_stream_id != 'conversations'
-        )
-
-        schemas, _ = get_schemas(self.client)
-
-        self.assertNotIn('conversation_parts', schemas)
-
-        checked = [c[0][1].tap_stream_id for c in mock_access.call_args_list]
-        self.assertNotIn('conversation_parts', checked)
-
-        warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
-        self.assertTrue(
-            any('conversation_parts' in m for m in warning_msgs),
-            msg="Expected a WARNING log mentioning 'conversation_parts'"
-        )
-
-    # -------------------------------------------------------------------
-    # prune_inaccessible_children called as post-processing step
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.schema.prune_inaccessible_children')
-    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
-    def test_prune_inaccessible_children_called(
-        self, _mock_access, mock_prune
-    ):
-        """get_schemas must call prune_inaccessible_children after the loop."""
-        get_schemas(self.client)
-
-        mock_prune.assert_called_once()
-
-    @mock.patch('tap_intercom.schema.check_stream_access')
-    def test_prune_removes_child_that_slipped_into_schemas(self, mock_access):
-        """
-        If a child stream enters schemas (check_stream_access returns True for
-        child streams now), prune_inaccessible_children must remove it when
-        the parent was denied.
-        """
-        # Allow child (check_stream_access returns True for it) but deny parent
-        mock_access.side_effect = (
-            lambda client, obj: obj.tap_stream_id != 'conversations'
-        )
-
-        schemas, field_metadata = get_schemas(self.client)
-
-        # After pruning, child must not appear
-        self.assertNotIn('conversation_parts', schemas)
-        self.assertNotIn('conversation_parts', field_metadata)
-
-    # -------------------------------------------------------------------
-    # All streams unauthorized -> raises IntercomError
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.schema.check_stream_access', return_value=False)
-    def test_all_streams_unauthorized_raises(self, _mock_access):
-        """All inaccessible -> IntercomError raised."""
-        with self.assertRaises(IntercomError):
-            get_schemas(self.client)
-
-    @mock.patch('tap_intercom.schema.LOGGER')
-    @mock.patch('tap_intercom.schema.check_stream_access', return_value=False)
-    def test_all_streams_unauthorized_logs_error(
-        self, _mock_access, mock_logger
-    ):
-        """All inaccessible -> error logged with 'No accessible streams'."""
-        with self.assertRaises(IntercomError):
-            get_schemas(self.client)
-
-        mock_logger.error.assert_called()
-        self.assertIn(
-            'No accessible streams', mock_logger.error.call_args[0][0]
-        )
-
-    # -------------------------------------------------------------------
-    # to_replicate=False streams are always skipped
-    # -------------------------------------------------------------------
-
-    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
-    def test_non_replicable_streams_never_checked(self, mock_access):
-        """Streams with to_replicate=False must skip check_stream_access."""
-        from tap_intercom.streams import STREAMS
-
+    def test_non_replicable_streams_excluded(self):
+        """Streams with to_replicate=False (e.g. admin_list) are absent."""
+        schemas, _ = get_schemas()
         non_replicable = [
             name for name, cls in STREAMS.items() if not cls.to_replicate
         ]
-        if not non_replicable:
-            self.skipTest('No non-replicable streams defined in STREAMS.')
+        for name in non_replicable:
+            self.assertNotIn(name, schemas)
 
-        get_schemas(self.client)
+    def test_schemas_and_metadata_keys_match(self):
+        """Every entry in schemas has a corresponding field_metadata entry."""
+        schemas, field_metadata = get_schemas()
+        self.assertEqual(set(schemas.keys()), set(field_metadata.keys()))
 
-        checked = [c[0][1].tap_stream_id for c in mock_access.call_args_list]
-        for stream_name in non_replicable:
-            self.assertNotIn(stream_name, checked)
+    def test_schemas_are_dicts(self):
+        """Each schema value is a dict."""
+        schemas, _ = get_schemas()
+        for name, schema in schemas.items():
+            self.assertIsInstance(
+                schema, dict, msg="{} schema is not a dict".format(name)
+            )
+
+    def test_field_metadata_are_lists(self):
+        """Each field_metadata value is a list (singer metadata format)."""
+        _, field_metadata = get_schemas()
+        for name, mdata in field_metadata.items():
+            self.assertIsInstance(
+                mdata, list,
+                msg="{} metadata is not a list".format(name)
+            )
+
+    def test_key_properties_in_metadata(self):
+        """Each stream's root metadata contains table-key-properties."""
+        _, field_metadata = get_schemas()
+        for name, mdata in field_metadata.items():
+            root_meta = next(
+                (m.get('metadata', {})
+                 for m in mdata if m.get('breadcrumb') == ()),
+                {}
+            )
+            self.assertIn(
+                'table-key-properties', root_meta,
+                msg="{} missing table-key-properties".format(name)
+            )
+
+    def test_replication_method_in_metadata(self):
+        """Each stream's root metadata contains forced-replication-method."""
+        _, field_metadata = get_schemas()
+        for name, mdata in field_metadata.items():
+            root_meta = next(
+                (m.get('metadata', {})
+                 for m in mdata if m.get('breadcrumb') == ()),
+                {}
+            )
+            self.assertIn(
+                'forced-replication-method', root_meta,
+                msg="{} missing forced-replication-method".format(name)
+            )
+
+    def test_no_client_required(self):
+        """get_schemas() must succeed without any client argument."""
+        try:
+            get_schemas()
+        except TypeError as exc:  # pragma: no cover
+            self.fail(
+                "get_schemas() raised TypeError (unexpected arg): {}".format(exc)
+            )
+
+
+if __name__ == '__main__':  # pragma: no cover
+    unittest.main()

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -6,6 +6,7 @@ from parameterized import parameterized
 from tap_intercom.client import (IntercomClient, IntercomError,
                                  IntercomForbiddenError, IntercomNotFoundError,
                                  IntercomRequestTimeoutError,
+                                 IntercomScrollExistsError,
                                  IntercomUnauthorizedError)
 from tap_intercom.schema import (check_stream_access, get_schemas,
                                  prune_inaccessible_children)
@@ -171,6 +172,40 @@ class TestCheckStreamAccess(unittest.TestCase):
         result = check_stream_access(self.client, stream_obj)
 
         self.assertFalse(result)
+
+    # -------------------------------------------------------------------
+    # scroll_exists (400) must return True — endpoint is reachable
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_scroll_exists_error_returns_true(self, mock_probe):
+        """
+        IntercomScrollExistsError means a scroll session is already open,
+        which proves the endpoint is reachable. Must return True, not False.
+        """
+        mock_probe.side_effect = IntercomScrollExistsError(
+            'HTTP-error-code: 400, Error:scroll already exists '
+            'for this workspace, Error_Code:scroll_exists'
+        )
+        stream_obj = _make_stream_obj('companies', 'companies/scroll')
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertTrue(result)
+
+    @mock.patch('tap_intercom.schema.LOGGER')
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_scroll_exists_logs_info_not_error(self, mock_probe, mock_logger):
+        """scroll_exists must log at INFO level, not ERROR."""
+        mock_probe.side_effect = IntercomScrollExistsError(
+            'HTTP-error-code: 400, Error_Code:scroll_exists'
+        )
+        stream_obj = _make_stream_obj('companies', 'companies/scroll')
+
+        check_stream_access(self.client, stream_obj)
+
+        mock_logger.error.assert_not_called()
+        mock_logger.info.assert_called()
 
     # -------------------------------------------------------------------
     # Parameterized: correct log level emitted

--- a/tests/unittests/test_schema.py
+++ b/tests/unittests/test_schema.py
@@ -1,0 +1,471 @@
+import unittest
+from unittest import mock
+
+from parameterized import parameterized
+
+from tap_intercom.client import (IntercomClient, IntercomError,
+                                 IntercomForbiddenError, IntercomNotFoundError,
+                                 IntercomRequestTimeoutError,
+                                 IntercomUnauthorizedError)
+from tap_intercom.schema import (check_stream_access, get_schemas,
+                                 prune_inaccessible_children)
+
+
+def _make_stream_obj(
+    tap_stream_id,
+    path,
+    parent=None,
+    to_replicate=True,
+    probe_http_method='GET',
+    params=None,
+    probe_search_query=None,
+):
+    """
+    Helper: returns a mock stream object with explicit attributes
+    so that MagicMock auto-creation does not pollute kwargs.
+    """
+    obj = mock.MagicMock()
+    obj.tap_stream_id = tap_stream_id
+    obj.path = path
+    obj.parent = parent
+    obj.to_replicate = to_replicate
+    obj.key_properties = ['id']
+    obj.valid_replication_keys = []
+    obj.replication_method = 'FULL_TABLE'
+    obj.replication_key = None
+    obj.probe_http_method = probe_http_method
+    obj.params = params if params is not None else {}
+    if probe_search_query is not None:
+        obj.probe_search_query = probe_search_query
+    return obj
+
+
+def _make_parent_obj(tap_stream_id):
+    """Returns a minimal mock representing a parent stream class."""
+    parent = mock.MagicMock()
+    parent.tap_stream_id = tap_stream_id
+    return parent
+
+
+# ---------------------------------------------------------------------------
+# Tests for check_stream_access()
+# ---------------------------------------------------------------------------
+
+class TestCheckStreamAccess(unittest.TestCase):
+    """Tests for check_stream_access()"""
+
+    def setUp(self):
+        self.client = IntercomClient(
+            access_token='test_token', config_request_timeout=''
+        )
+
+    # -------------------------------------------------------------------
+    # Child streams return True immediately — probe_stream never called
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_child_stream_returns_true_without_probe(self, mock_probe):
+        """
+        Streams with a parent must return True immediately;
+        probe_stream must never be called for them.
+        """
+        parent = _make_parent_obj('conversations')
+        stream_obj = _make_stream_obj('conversation_parts', 'conversations/{}',
+                                      parent=parent)
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertTrue(result)
+        mock_probe.assert_not_called()
+
+    # -------------------------------------------------------------------
+    # GET stream — probe called with correct kwargs
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_get_stream_probe_called_with_get_method(self, mock_probe):
+        """GET stream: probe_stream called with http_method='GET'."""
+        mock_probe.return_value = {'type': 'list'}
+        stream_obj = _make_stream_obj('tags', 'tags',
+                                      probe_http_method='GET',
+                                      params={'include_count': 'true'})
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertTrue(result)
+        mock_probe.assert_called_once_with(
+            'tags',
+            http_method='GET',
+            params={'include_count': 'true'},
+            json={},
+        )
+
+    # -------------------------------------------------------------------
+    # POST stream — probe called with http_method='POST' and search query
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_post_stream_probe_called_with_post_method_and_query(
+        self, mock_probe
+    ):
+        """POST stream: probe_stream called with http_method='POST' and json body."""
+        mock_probe.return_value = {'conversations': []}
+        probe_query = {
+            'pagination': {'per_page': 1},
+            'query': {'field': 'id', 'operator': '!=', 'value': None},
+        }
+        stream_obj = _make_stream_obj(
+            'conversations', 'conversations/search',
+            probe_http_method='POST',
+            probe_search_query=probe_query,
+        )
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertTrue(result)
+        mock_probe.assert_called_once_with(
+            'conversations/search',
+            http_method='POST',
+            params={},
+            json=probe_query,
+        )
+
+    # -------------------------------------------------------------------
+    # Accessible stream returns True
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_accessible_stream_returns_true(self, mock_probe):
+        """probe_stream succeeds -> returns True."""
+        mock_probe.return_value = {'type': 'list'}
+        stream_obj = _make_stream_obj('tags', 'tags')
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertTrue(result)
+
+    # -------------------------------------------------------------------
+    # Parameterized: various IntercomError subclasses -> returns False
+    # -------------------------------------------------------------------
+
+    @parameterized.expand([
+        ['401_unauthorized',
+         IntercomUnauthorizedError, 'HTTP-error-code: 401', 'contacts'],
+        ['403_forbidden',
+         IntercomForbiddenError, 'HTTP-error-code: 403', 'companies'],
+        ['404_not_found',
+         IntercomNotFoundError, 'HTTP-error-code: 404', 'segments'],
+        ['408_request_timeout',
+         IntercomRequestTimeoutError, 'HTTP-error-code: 408', 'teams'],
+        ['generic_intercom_error',
+         IntercomError, 'some permission error', 'tags'],
+    ])
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_error_returns_false(
+        self, _name, exc_class, exc_msg, stream_name, mock_probe
+    ):
+        """Any IntercomError (or subclass) -> returns False, never re-raised."""
+        mock_probe.side_effect = exc_class(exc_msg)
+        stream_obj = _make_stream_obj(stream_name, stream_name)
+
+        result = check_stream_access(self.client, stream_obj)
+
+        self.assertFalse(result)
+
+    # -------------------------------------------------------------------
+    # Parameterized: correct log level emitted
+    # -------------------------------------------------------------------
+
+    @parameterized.expand([
+        ['unauthorized_logs_error',
+         IntercomUnauthorizedError('HTTP-error-code: 401'), 'error', True],
+        ['forbidden_logs_error',
+         IntercomForbiddenError('HTTP-error-code: 403'), 'error', True],
+        ['accessible_does_not_log_error', None, 'error', False],
+    ])
+    @mock.patch('tap_intercom.schema.LOGGER')
+    @mock.patch('tap_intercom.client.IntercomClient.probe_stream')
+    def test_log_behaviour(
+        self, _name, exc, log_method, expect_called, mock_probe, mock_logger
+    ):
+        """Verify the correct log level is (or is not) triggered."""
+        if exc:
+            mock_probe.side_effect = exc
+        else:
+            mock_probe.return_value = {}
+
+        stream_obj = _make_stream_obj('contacts', 'contacts')
+        check_stream_access(self.client, stream_obj)
+
+        logger_fn = getattr(mock_logger, log_method)
+        if expect_called:
+            logger_fn.assert_called_once()
+            self.assertIn('contacts', logger_fn.call_args[0][0])
+        else:
+            logger_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tests for prune_inaccessible_children()
+# ---------------------------------------------------------------------------
+
+class TestPruneInaccessibleChildren(unittest.TestCase):
+    """Tests for prune_inaccessible_children()"""
+
+    def _schemas_and_meta(self, stream_names):
+        """Build minimal schemas/field_metadata dicts for the given stream names."""
+        schemas = {name: {'type': 'object'} for name in stream_names}
+        field_metadata = {name: [] for name in stream_names}
+        return schemas, field_metadata
+
+    def test_child_removed_from_schemas_when_parent_inaccessible(self):
+        """
+        conversation_parts must be removed from schemas when its parent
+        (conversations) is in inaccessible_streams.
+        """
+        schemas, field_metadata = self._schemas_and_meta(
+            ['conversations', 'conversation_parts', 'tags']
+        )
+        inaccessible = ['conversations']
+
+        prune_inaccessible_children(schemas, field_metadata, inaccessible)
+
+        self.assertNotIn('conversation_parts', schemas)
+        self.assertNotIn('conversation_parts', field_metadata)
+
+    def test_child_removed_from_field_metadata_when_parent_inaccessible(self):
+        """field_metadata entry for the child must also be pruned."""
+        schemas, field_metadata = self._schemas_and_meta(
+            ['conversations', 'conversation_parts']
+        )
+        prune_inaccessible_children(schemas, field_metadata, ['conversations'])
+
+        self.assertNotIn('conversation_parts', field_metadata)
+
+    def test_unrelated_streams_unaffected_by_pruning(self):
+        """Streams whose parent is not inaccessible must remain in schemas."""
+        schemas, field_metadata = self._schemas_and_meta(
+            ['conversations', 'conversation_parts', 'tags', 'teams']
+        )
+        prune_inaccessible_children(schemas, field_metadata, ['conversations'])
+
+        self.assertIn('tags', schemas)
+        self.assertIn('teams', schemas)
+
+    def test_no_pruning_when_no_inaccessible_streams(self):
+        """No streams should be removed when inaccessible_streams is empty."""
+        schemas, field_metadata = self._schemas_and_meta(
+            ['conversations', 'conversation_parts', 'tags']
+        )
+        prune_inaccessible_children(schemas, field_metadata, [])
+
+        self.assertIn('conversation_parts', schemas)
+        self.assertIn('conversation_parts', field_metadata)
+
+    def test_noop_when_child_not_already_in_schemas(self):
+        """
+        prune_inaccessible_children must not raise even if the child stream
+        was never added to schemas (e.g. already skipped during discovery).
+        """
+        schemas, field_metadata = self._schemas_and_meta(['tags'])
+        # conversations is inaccessible but conversation_parts is not in schemas
+        try:
+            prune_inaccessible_children(
+                schemas, field_metadata, ['conversations']
+            )
+        except KeyError:
+            self.fail(
+                'prune_inaccessible_children raised KeyError for a child '
+                'stream that was not in schemas.'
+            )
+
+    @parameterized.expand([
+        ['conversations_inaccessible', 'conversations', 'conversation_parts'],
+    ])
+    def test_parameterized_parent_child_pruning(
+        self, _name, inaccessible_parent, expected_removed_child
+    ):
+        """Parameterized: given inaccessible parent, child is pruned."""
+        schemas, field_metadata = self._schemas_and_meta(
+            [inaccessible_parent, expected_removed_child, 'tags']
+        )
+
+        prune_inaccessible_children(
+            schemas, field_metadata, [inaccessible_parent]
+        )
+
+        self.assertNotIn(expected_removed_child, schemas)
+        self.assertNotIn(expected_removed_child, field_metadata)
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_schemas()
+# ---------------------------------------------------------------------------
+
+class TestGetSchemas(unittest.TestCase):
+    """Tests for get_schemas()"""
+
+    def setUp(self):
+        self.client = IntercomClient(
+            access_token='test_token', config_request_timeout=''
+        )
+
+    # -------------------------------------------------------------------
+    # All streams authorized
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
+    def test_all_streams_authorized_all_included(self, _mock_access):
+        """All accessible -> all replicable streams appear in the catalog."""
+        schemas, field_metadata = get_schemas(self.client)
+
+        self.assertGreater(len(schemas), 0)
+        self.assertEqual(set(schemas.keys()), set(field_metadata.keys()))
+
+    # -------------------------------------------------------------------
+    # Parameterized: single unauthorized stream excluded; others survive
+    # -------------------------------------------------------------------
+
+    @parameterized.expand([
+        ['tags_denied',     'tags'],
+        ['teams_denied',    'teams'],
+        ['segments_denied', 'segments'],
+    ])
+    @mock.patch('tap_intercom.schema.check_stream_access')
+    def test_unauthorized_stream_excluded_from_catalog(
+        self, _name, denied_stream, mock_access
+    ):
+        """A denied stream must not appear in schemas output."""
+        mock_access.side_effect = (
+            lambda client, obj: obj.tap_stream_id != denied_stream
+        )
+
+        schemas, _ = get_schemas(self.client)
+
+        self.assertNotIn(denied_stream, schemas)
+
+    @parameterized.expand([
+        ['tags_denied',     'tags',     ['teams', 'contacts', 'segments']],
+        ['teams_denied',    'teams',    ['tags',  'contacts', 'segments']],
+        ['segments_denied', 'segments', ['tags',  'teams',    'contacts']],
+    ])
+    @mock.patch('tap_intercom.schema.check_stream_access')
+    def test_authorized_streams_unaffected_when_one_unauthorized(
+        self, _name, denied_stream, expected_present, mock_access
+    ):
+        """Authorized streams must still appear when one stream is denied."""
+        mock_access.side_effect = (
+            lambda client, obj: obj.tap_stream_id != denied_stream
+        )
+
+        schemas, _ = get_schemas(self.client)
+
+        for stream in expected_present:
+            self.assertIn(stream, schemas)
+
+    # -------------------------------------------------------------------
+    # Child stream excluded when parent is inaccessible (early-continue path)
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.schema.LOGGER')
+    @mock.patch('tap_intercom.schema.check_stream_access')
+    def test_child_excluded_when_parent_inaccessible(
+        self, mock_access, mock_logger
+    ):
+        """
+        conversation_parts (child of conversations) must be excluded
+        without calling check_stream_access for it, and a WARNING logged.
+        """
+        mock_access.side_effect = (
+            lambda client, obj: obj.tap_stream_id != 'conversations'
+        )
+
+        schemas, _ = get_schemas(self.client)
+
+        self.assertNotIn('conversation_parts', schemas)
+
+        checked = [c[0][1].tap_stream_id for c in mock_access.call_args_list]
+        self.assertNotIn('conversation_parts', checked)
+
+        warning_msgs = [str(c) for c in mock_logger.warning.call_args_list]
+        self.assertTrue(
+            any('conversation_parts' in m for m in warning_msgs),
+            msg="Expected a WARNING log mentioning 'conversation_parts'"
+        )
+
+    # -------------------------------------------------------------------
+    # prune_inaccessible_children called as post-processing step
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.schema.prune_inaccessible_children')
+    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
+    def test_prune_inaccessible_children_called(
+        self, _mock_access, mock_prune
+    ):
+        """get_schemas must call prune_inaccessible_children after the loop."""
+        get_schemas(self.client)
+
+        mock_prune.assert_called_once()
+
+    @mock.patch('tap_intercom.schema.check_stream_access')
+    def test_prune_removes_child_that_slipped_into_schemas(self, mock_access):
+        """
+        If a child stream enters schemas (check_stream_access returns True for
+        child streams now), prune_inaccessible_children must remove it when
+        the parent was denied.
+        """
+        # Allow child (check_stream_access returns True for it) but deny parent
+        mock_access.side_effect = (
+            lambda client, obj: obj.tap_stream_id != 'conversations'
+        )
+
+        schemas, field_metadata = get_schemas(self.client)
+
+        # After pruning, child must not appear
+        self.assertNotIn('conversation_parts', schemas)
+        self.assertNotIn('conversation_parts', field_metadata)
+
+    # -------------------------------------------------------------------
+    # All streams unauthorized -> raises IntercomError
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.schema.check_stream_access', return_value=False)
+    def test_all_streams_unauthorized_raises(self, _mock_access):
+        """All inaccessible -> IntercomError raised."""
+        with self.assertRaises(IntercomError):
+            get_schemas(self.client)
+
+    @mock.patch('tap_intercom.schema.LOGGER')
+    @mock.patch('tap_intercom.schema.check_stream_access', return_value=False)
+    def test_all_streams_unauthorized_logs_error(
+        self, _mock_access, mock_logger
+    ):
+        """All inaccessible -> error logged with 'No accessible streams'."""
+        with self.assertRaises(IntercomError):
+            get_schemas(self.client)
+
+        mock_logger.error.assert_called()
+        self.assertIn(
+            'No accessible streams', mock_logger.error.call_args[0][0]
+        )
+
+    # -------------------------------------------------------------------
+    # to_replicate=False streams are always skipped
+    # -------------------------------------------------------------------
+
+    @mock.patch('tap_intercom.schema.check_stream_access', return_value=True)
+    def test_non_replicable_streams_never_checked(self, mock_access):
+        """Streams with to_replicate=False must skip check_stream_access."""
+        from tap_intercom.streams import STREAMS
+
+        non_replicable = [
+            name for name, cls in STREAMS.items() if not cls.to_replicate
+        ]
+        if not non_replicable:
+            self.skipTest('No non-replicable streams defined in STREAMS.')
+
+        get_schemas(self.client)
+
+        checked = [c[0][1].tap_stream_id for c in mock_access.call_args_list]
+        for stream_name in non_replicable:
+            self.assertNotIn(stream_name, checked)

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -4,7 +4,9 @@ import datetime as dt
 from unittest import mock
 from tap_intercom.client import IntercomClient, IntercomError, IntercomNotFoundError
 from parameterized import parameterized
-from tap_intercom.streams import AdminList, BaseStream, Admins,Companies, CompanyAttributes, Contacts, ContactAttributes, CompanySegments, Conversations, Segments, Tags, Teams, ConversationParts
+from tap_intercom.streams import (AdminList, BaseStream, Admins, Companies, CompanyAttributes,
+                                   Contacts, ContactAttributes, CompanySegments, Conversations,
+                                   Segments, Tags, Teams, ConversationParts, IncrementalStream)
 
 class TestData(unittest.TestCase):
 
@@ -103,3 +105,169 @@ class TestFullTable(unittest.TestCase):
         test_data = test_stream.sync("test","","","","")
 
         self.assertEqual(test_data,"test")
+
+
+class TestBaseStreamCoverage(unittest.TestCase):
+
+    base_client = IntercomClient("test", "300")
+
+    def test_get_records_raises_not_implemented(self):
+        """BaseStream.get_records raises NotImplementedError."""
+        stream = BaseStream()
+        with self.assertRaises(NotImplementedError):
+            list(stream.get_records())
+
+    def test_incremental_stream_base_set_last_processed(self):
+        """IncrementalStream.set_last_processed base sets last_processed to None."""
+        stream = Segments(self.base_client, None, [])
+        stream.last_processed = 'some-value'
+        stream.set_last_processed({})
+        self.assertIsNone(stream.last_processed)
+
+    def test_incremental_stream_base_get_last_sync_started_at(self):
+        """IncrementalStream.get_last_sync_started_at base sets attribute to None."""
+        stream = Segments(self.base_client, None, [])
+        stream.last_sync_started_at = 'some-value'
+        stream.get_last_sync_started_at({})
+        self.assertIsNone(stream.last_sync_started_at)
+
+    def test_incremental_stream_base_set_last_sync_started_at(self):
+        """IncrementalStream.set_last_sync_started_at base is a no-op."""
+        stream = Segments(self.base_client, None, [])
+        stream.set_last_sync_started_at({})  # should not raise
+
+    def test_incremental_stream_base_skip_records_returns_false(self):
+        """IncrementalStream.skip_records base always returns False."""
+        stream = Segments(self.base_client, None, [])
+        self.assertFalse(stream.skip_records({'id': '1'}))
+
+    @mock.patch('singer.write_bookmark', side_effect=singer.write_bookmark)
+    def test_incremental_stream_base_write_bookmark(self, _mock):
+        """IncrementalStream.write_bookmark base writes to state."""
+        stream = Segments(self.base_client, None, [])
+        state = {'bookmarks': {}}
+        result = stream.write_bookmark(state, '2022-01-01')
+        self.assertEqual(
+            result['bookmarks']['segments']['updated_at'], '2022-01-01'
+        )
+
+    @mock.patch('singer.write_state')
+    @mock.patch('singer.write_bookmark', side_effect=singer.write_bookmark)
+    def test_incremental_stream_write_intermediate_bookmark_when_enabled(self, _wb, _ws):
+        """write_intermediate_bookmark writes when to_write_intermediate_bookmark=True."""
+        stream = Contacts(self.base_client, None, [])
+        state = {'bookmarks': {}}
+        bm_dt = singer.utils.strptime_to_utc('2022-01-01T00:00:00Z')
+        stream.write_intermediate_bookmark(state, 'last-id', bm_dt)
+        self.assertIn('updated_at', state.get('bookmarks', {}).get('contacts', {}))
+
+    @mock.patch('tap_intercom.client.IntercomClient.get')
+    def test_admin_list_get_records_is_parent(self, mocked_get):
+        """AdminList.get_records(is_parent=True) yields admin ids."""
+        mocked_get.return_value = {'admins': [{'id': 'a1'}, {'id': 'a2'}]}
+        stream = AdminList(self.base_client, None, [])
+        result = list(stream.get_records(is_parent=True))
+        self.assertEqual(result, ['a1', 'a2'])
+
+
+    @mock.patch('tap_intercom.client.IntercomClient.get')
+    def test_companies_get_records_pagination(self, mocked_get):
+        """Companies.get_records follows scroll_param pages."""
+        mocked_get.side_effect = [
+            {'data': [{'id': '1', 'updated_at': 1}], 'scroll_param': 'tok'},
+            IntercomNotFoundError(),
+        ]
+        stream = Companies(self.base_client, None, [])
+        result = list(stream.get_records())
+        self.assertEqual(len(result), 1)
+
+
+class TestConversationsBookmarks(unittest.TestCase):
+
+    base_client = IntercomClient("test", "300")
+
+    @mock.patch('singer.write_bookmark', side_effect=singer.write_bookmark)
+    def test_write_bookmark_uses_last_sync_started_at(self, _mock):
+        """write_bookmark replaces bookmark with last_sync_started_at when present."""
+        stream = Conversations(self.base_client, None, [])
+        state = {
+            'bookmarks': {
+                'conversations': {
+                    'updated_at': '2022-01-01',
+                    'last_sync_started_at': '2022-06-01',
+                    'last_processed': 'conv-50',
+                }
+            }
+        }
+        result = stream.write_bookmark(state, '2022-01-01')
+        self.assertEqual(result['bookmarks']['conversations']['updated_at'], '2022-06-01')
+        self.assertNotIn('last_sync_started_at', result['bookmarks']['conversations'])
+        self.assertNotIn('last_processed', result['bookmarks']['conversations'])
+
+    @mock.patch('singer.write_state')
+    @mock.patch('singer.write_bookmark', side_effect=singer.write_bookmark)
+    def test_write_intermediate_bookmark(self, _wb, _ws):
+        """write_intermediate_bookmark writes last_processed and last_sync_started_at."""
+        stream = Conversations(self.base_client, None, [])
+        stream.last_sync_started_at = '2022-06-01'
+        state = {'bookmarks': {}}
+        stream.write_intermediate_bookmark(state, 'conv-42', None)
+        self.assertEqual(
+            state['bookmarks']['conversations']['last_processed'], 'conv-42'
+        )
+        self.assertEqual(
+            state['bookmarks']['conversations']['last_sync_started_at'], '2022-06-01'
+        )
+
+    @mock.patch('tap_intercom.client.IntercomClient.post')
+    def test_get_records_is_parent_yields_ids(self, mocked_post):
+        """Conversations.get_records(is_parent=True) yields conversation ids."""
+        mocked_post.return_value = {
+            'conversations': [{'id': 'c1'}, {'id': 'c2'}],
+            'pages': {'next': None},
+        }
+        stream = Conversations(self.base_client, None, [])
+        bookmark = singer.utils.strptime_to_utc('2022-01-01T00:00:00Z')
+        result = list(stream.get_records(bookmark_datetime=bookmark, is_parent=True))
+        self.assertEqual(result, ['c1', 'c2'])
+
+    @mock.patch('tap_intercom.client.IntercomClient.post')
+    def test_get_records_pagination(self, mocked_post):
+        """Conversations.get_records follows next-page pagination."""
+        mocked_post.side_effect = [
+            {
+                'conversations': [{'id': 'c1', 'updated_at': 1}],
+                'pages': {'next': {'starting_after': 'cursor1'}, 'page': 1},
+            },
+            {
+                'conversations': [{'id': 'c2', 'updated_at': 2}],
+                'pages': {},
+            },
+        ]
+        stream = Conversations(self.base_client, None, [])
+        bookmark = singer.utils.strptime_to_utc('2022-01-01T00:00:00Z')
+        result = list(stream.get_records(bookmark_datetime=bookmark))
+        self.assertEqual(len(result), 2)
+
+
+class TestContactsPagination(unittest.TestCase):
+
+    base_client = IntercomClient("test", "300")
+
+    @mock.patch('tap_intercom.client.IntercomClient.post')
+    def test_contacts_get_records_pagination(self, mocked_post):
+        """Contacts.get_records follows next-page pagination."""
+        mocked_post.side_effect = [
+            {
+                'data': [{'id': 'u1', 'tags': {}, 'companies': {}}],
+                'pages': {'next': {'starting_after': 'cursor1'}, 'page': 1},
+            },
+            {
+                'data': [{'id': 'u2', 'tags': {}, 'companies': {}}],
+                'pages': {},
+            },
+        ]
+        stream = Contacts(self.base_client, None, [])
+        bookmark = singer.utils.strptime_to_utc('2022-01-01T00:00:00Z')
+        result = list(stream.get_records(bookmark_datetime=bookmark, stream_metadata={}))
+        self.assertEqual(len(result), 2)

--- a/tests/unittests/test_stream.py
+++ b/tests/unittests/test_stream.py
@@ -169,7 +169,6 @@ class TestBaseStreamCoverage(unittest.TestCase):
         result = list(stream.get_records(is_parent=True))
         self.assertEqual(result, ['a1', 'a2'])
 
-
     @mock.patch('tap_intercom.client.IntercomClient.get')
     def test_companies_get_records_pagination(self, mocked_get):
         """Companies.get_records follows scroll_param pages."""
@@ -271,3 +270,59 @@ class TestContactsPagination(unittest.TestCase):
         bookmark = singer.utils.strptime_to_utc('2022-01-01T00:00:00Z')
         result = list(stream.get_records(bookmark_datetime=bookmark, stream_metadata={}))
         self.assertEqual(len(result), 2)
+
+
+class TestSyncSubstreamInnerLoop(unittest.TestCase):
+    """sync_substream inner loop (lines 191-198) needs actual conv parts in response."""
+
+    base_client = IntercomClient("test", "300")
+
+    @mock.patch('singer.write_state')
+    @mock.patch('singer.write_bookmark', side_effect=singer.write_bookmark)
+    @mock.patch('singer.write_record')
+    @mock.patch('tap_intercom.client.IntercomClient.get')
+    def test_sync_substream_with_actual_parts(self, mocked_get, mock_write_record, _wb, _ws):
+        """sync_substream writes records when response contains conversation_parts."""
+        mocked_get.return_value = {
+            'id': 'conv-1',
+            'created_at': 1640636000000,
+            'updated_at': 1640636000000,
+            'conversation_parts': {
+                'conversation_parts': [
+                    {'id': 'part-1', 'updated_at': 1640636000000,
+                     'author': {}, 'body': 'hi'},
+                ],
+            },
+        }
+        stream = ConversationParts(self.base_client, None, [])
+        state = {'bookmarks': {}}
+        stream.sync_substream('conv-1', {}, {}, 1640636000000, state)
+        self.assertGreater(mock_write_record.call_count, 0)
+
+
+class TestAdminsGetParentData(unittest.TestCase):
+
+    base_client = IntercomClient("test", "300")
+
+    @mock.patch('tap_intercom.client.IntercomClient.get')
+    def test_get_parent_data_calls_admin_list(self, mocked_get):
+        """Admins.get_parent_data delegates to AdminList.get_records(is_parent=True)."""
+        mocked_get.return_value = {'admins': [{'id': 'a1'}, {'id': 'a2'}]}
+        stream = Admins(self.base_client, None, [])
+        result = list(stream.get_parent_data())
+        self.assertEqual(result, ['a1', 'a2'])
+
+
+class TestCompaniesNullDataWarning(unittest.TestCase):
+
+    base_client = IntercomClient("test", "300")
+
+    @mock.patch('tap_intercom.streams.LOGGER')
+    @mock.patch('tap_intercom.client.IntercomClient.get')
+    def test_null_data_key_logs_warning(self, mocked_get, mock_logger):
+        """Companies.get_records logs a warning when data key is absent from response."""
+        # Empty response → data key missing → warning; then NotFound to stop loop
+        mocked_get.side_effect = [{}, IntercomNotFoundError()]
+        stream = Companies(self.base_client, None, [])
+        list(stream.get_records())
+        mock_logger.warning.assert_called()

--- a/tests/unittests/test_translate_state.py
+++ b/tests/unittests/test_translate_state.py
@@ -73,3 +73,28 @@ class TestTranslateState(unittest.TestCase):
 
         # Verify that returned state is same for new formatted state
         self.assertEqual(new_state, new_format_state)
+
+
+class TestGetStreamsToSync(unittest.TestCase):
+
+    def test_admins_stream_included_directly(self):
+        """When 'admins' is selected, get_streams_to_sync adds catalog admins stream."""
+        from tap_intercom.sync import get_streams_to_sync
+        from tap_intercom.streams import Admins
+
+        class _FakeStream:
+            def __init__(self, tap_stream_id):
+                self.tap_stream_id = tap_stream_id
+
+        class _FakeCatalog:
+            def get_stream(self, name):
+                return _FakeStream(name)
+
+        admins_obj = Admins.__new__(Admins)
+        admins_obj.tap_stream_id = 'admins'
+
+        result = get_streams_to_sync(
+            _FakeCatalog(), [admins_obj], ['admins']
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].tap_stream_id, 'admins')


### PR DESCRIPTION

# Description of change
- Added access token context manager check in init
- Streams are now probed during schema creation to check accessibility
- Un-auth streams are removed from the catalog by doing a small probe.
- Added unittests.
JIRA: https://qlik-dev.atlassian.net/browse/SAC-30973

# Manual QA steps
- [x] Unittests running

 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
